### PR TITLE
Include 'trigger_reset_actions' when creating AlertDefinitionInput

### DIFF
--- a/examples/resources/swo_alert/resource.tf
+++ b/examples/resources/swo_alert/resource.tf
@@ -30,4 +30,5 @@ resource "swo_alert" "https_response_time" {
     },
   ]
   notifications = [swo_notification.msteams.id, swo_notification.opsgenie.id]
+  trigger_reset_actions = true
 }

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -143,7 +143,7 @@ func (model *alertResourceModel) toAlertDefinitionInput() swoClient.AlertDefinit
 		Enabled:     model.Enabled.ValueBool(),
 		Severity:    swoClient.AlertSeverity(model.Severity.ValueString()),
 		Actions:     model.toAlertActionInput(),
-    TriggerResetActions: model.TriggerResetActions.ValueBoolPointer(),
+		TriggerResetActions: model.TriggerResetActions.ValueBoolPointer(),
 		Condition:   conditions,
 	}
 }

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -143,6 +143,7 @@ func (model *alertResourceModel) toAlertDefinitionInput() swoClient.AlertDefinit
 		Enabled:     model.Enabled.ValueBool(),
 		Severity:    swoClient.AlertSeverity(model.Severity.ValueString()),
 		Actions:     model.toAlertActionInput(),
+    TriggerResetActions: model.TriggerResetActions.ValueBoolPointer(),
 		Condition:   conditions,
 	}
 }

--- a/internal/provider/alert_resource_test.go
+++ b/internal/provider/alert_resource_test.go
@@ -22,6 +22,7 @@ func TestAccAlertResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_alert.test", "severity", "CRITICAL"),
 					resource.TestCheckResourceAttr("swo_alert.test", "type", "ENTITY_METRIC"),
 					resource.TestCheckResourceAttr("swo_alert.test", "target_entity_types.0", "Website"),
+					resource.TestCheckResourceAttr("swo_alert.test", "trigger_reset_actions", "true"),
 					// Verify number of conditions.
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.#", "1"),
 					// Verify the conditions.
@@ -66,6 +67,7 @@ resource "swo_alert" "test" {
   type        = "ENTITY_METRIC"
 	enabled     = true
   target_entity_types = ["Website"]
+	trigger_reset_actions = true
   conditions = [
     {
       metric_name      = "synthetics.https.response.time"


### PR DESCRIPTION
Fixing an issue that when creating an alert, setting `trigger_reset_actions` to `true` did not do anything. With these proposed changes it propagates correctly to the API.

First I tried with the current (0.0.16) version, and indeed the issue was present, after finding the fix I built the provider locally and tested it locally and can confirm that it fixes the issue.