### PR TITLE
fix(alert_resource): exclude_tags GQL mapping

### DIFF
--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -204,15 +204,20 @@ func (model *alertConditionModel) toMetricFieldConditionInput() swoClient.AlertC
 			propertyName := tag.Name.ValueString()
 			metricFilter := swoClient.AlertFilterExpressionInput{
 				PropertyName:   &propertyName,
-				Operation:      swoClient.FilterOperationNe,
+				Operation:      swoClient.FilterOperationIn,
 				PropertyValues: tag.Values,
 			}
 
+			metricFilterNotOp := swoClient.AlertFilterExpressionInput{
+				Operation: swoClient.FilterOperationNot,
+			}
+
+			metricFilterNotOp.Children = append(metricFilterNotOp.Children, metricFilter)
+
 			metricFieldCondition.MetricFilter.Children = append(
 				metricFieldCondition.MetricFilter.Children,
-				metricFilter,
+				metricFilterNotOp,
 			)
-
 		}
 	}
 

--- a/internal/provider/alert_resource_test.go
+++ b/internal/provider/alert_resource_test.go
@@ -11,6 +11,7 @@ func TestAccAlertResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -34,6 +35,8 @@ func TestAccAlertResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.include_tags.0.name", "probe.city"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.include_tags.0.values.0", "Tokyo"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.include_tags.0.values.1", "Sao Paulo"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.exclude_tags.0.name", "service.name"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.exclude_tags.0.values.0", "test-service"),
 					resource.TestCheckResourceAttr("swo_alert.test", "notifications.0", "123"),
 					resource.TestCheckResourceAttr("swo_alert.test", "notifications.1", "456"),
 				),
@@ -84,7 +87,12 @@ resource "swo_alert" "test" {
           ]
         }
       ],
-      exclude_tags = []
+      exclude_tags = [{
+          name = "service.name"
+          values : [
+            "test-service"
+          ]
+        }]
     },
   ]
   notifications = ["123", "456"]


### PR DESCRIPTION
In the alert_resource exclude_tags were not mapping correctly to the GQL mutation. 

In the create alert mutation when using a metricFilter the `NE` operator cannot be used as the child of a metricFilter without a `propertyValue`. An array of `propertyValues` was being set which left `propertyValue` nil. 

The solution was to create a child of the top level metricFilter with the `NOT` operator that has another child metricFilter containing the exclude_tags as `propertyValues` with the `IN` operator. 

Example metric filter with include and exclude tags:

```
"metricFilter": {
     "propertyName": null,
     "propertyValue": null,
     "propertyValues": null,
     "operation": "AND",
     "children": [
      {
     "operation": "NOT",
     "children": [
      {
       "propertyName": "service.name",
       "propertyValue": null,
       "propertyValues": ["test-service"],
       "operation": "IN",
       "children": null
      }
     ]
      },
      {
       "propertyName": "probe.city",
       "propertyValue": null,
       "propertyValues": ["Tokyo"],
       "operation": "IN",
       "children": null
      }
     ]
    },
```