### PR TITLE
[feat] alerts support more than one alert condition

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -20,7 +20,7 @@ resource "swo_alert" "https_response_time" {
   enabled     = true
   notification_actions = [
     {
-      configuration_ids       = [swo_notification.msteams.id, swo_notification.opsgenie.id]
+      configuration_ids       = ["4661:email", "8112:webhook", "2456:newrelic"]
       resend_interval_seconds = 600
     },
   ]
@@ -50,7 +50,7 @@ resource "swo_alert" "https_response_time" {
       exclude_tags = []
     },
   ]
-  notifications         = [swo_notification.msteams.id, swo_notification.opsgenie.id]
+  notifications         = ["4661:email", "8112:webhook", "2456:newrelic"]
   trigger_reset_actions = true
   runbookLink           = "https://www.runbook.com/highresponsetime"
 }

--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -35,8 +35,9 @@ type ConditionMap struct {
 //	         /    \
 //	Metric Field   10m
 //	    (id=2)    (duration, id=3)
-func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.AlertConditionNodeInput, rootNodeId int) []swoClient.AlertConditionNodeInput {
+func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.AlertConditionNodeInput) []swoClient.AlertConditionNodeInput {
 
+	rootNodeId := 0
 	thresholdOperatorCondition, thresholdDataCondition := model.toThresholdConditionInputs()
 	thresholdOperatorCondition.Id = rootNodeId
 	thresholdOperatorCondition.OperandIds = []int{rootNodeId + 1, rootNodeId + 4}

--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -27,35 +27,31 @@ type ConditionMap struct {
 //
 // An example of a simple metric condition tree:
 //
-//	  							>=
-//					(threshold operator, id=0)
-//	       						/  \
-//	       		 			AVG  	42
-//			(aggregation, id=1)   (threshold data, id=4)
-//	     			/  	\
-//		Metric Field    10m
-//		(id=2) 		   (duration, id=3)
-func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.AlertConditionNodeInput) []swoClient.AlertConditionNodeInput {
+//	                       >=
+//	            (threshold operator, id=0)
+//	                      /  \
+//	                    AVG    42
+//	     (aggregation, id=1)   (threshold data, id=4)
+//	         /    \
+//	Metric Field   10m
+//	    (id=2)    (duration, id=3)
+func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.AlertConditionNodeInput, rootNodeId int) []swoClient.AlertConditionNodeInput {
 
-	rootNode := 0
-	// todo  possible reuse for multi conditions
-	//conditionsReturnedLen := len(conditionMaps)
-	//lastId := len(conditions) + conditionsReturnedLen
 	thresholdOperatorCondition, thresholdDataCondition := model.toThresholdConditionInputs()
-	thresholdOperatorCondition.Id = rootNode
-	thresholdOperatorCondition.OperandIds = []int{rootNode + 1, rootNode + 4}
+	thresholdOperatorCondition.Id = rootNodeId
+	thresholdOperatorCondition.OperandIds = []int{rootNodeId + 1, rootNodeId + 4}
 
 	aggregationCondition := model.toAggregationConditionInput()
-	aggregationCondition.Id = rootNode + 1
-	aggregationCondition.OperandIds = []int{rootNode + 2, rootNode + 3}
+	aggregationCondition.Id = rootNodeId + 1
+	aggregationCondition.OperandIds = []int{rootNodeId + 2, rootNodeId + 3}
 
 	metricFieldCondition := model.toMetricFieldConditionInput()
-	metricFieldCondition.Id = rootNode + 2
+	metricFieldCondition.Id = rootNodeId + 2
 
 	durationCondition := model.toDurationConditionInput()
-	durationCondition.Id = rootNode + 3
+	durationCondition.Id = rootNodeId + 3
 
-	thresholdDataCondition.Id = rootNode + 4
+	thresholdDataCondition.Id = rootNodeId + 4
 
 	conditionsOrdered := []swoClient.AlertConditionNodeInput{
 		thresholdOperatorCondition,
@@ -64,12 +60,12 @@ func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.A
 		durationCondition,
 		thresholdDataCondition,
 	}
-	// todo keep append to master list we can re-use for multi conditions...
+
 	return append(conditions, conditionsOrdered...)
 }
 
 // Creates the threshold operation and threshold data nodes by either:
-//  1. If not_reporting=true, operator is set to '=' and value to '0'
+//  1. If model.not_reporting=true, operator is set to '=' and value to '0'
 //  2. Else, parse the model.threshold string into operator and value
 //     Ex:">=3000" -> operator '>=' and value '3000'
 func (model *alertConditionModel) toThresholdConditionInputs() (swoClient.AlertConditionNodeInput, swoClient.AlertConditionNodeInput) {

--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -1,27 +1,16 @@
 package provider
 
 import (
-	"log"
+	"errors"
 	"regexp"
 	"strconv"
 
 	swoClient "github.com/solarwinds/swo-client-go/pkg/client"
 )
 
-type conditionType string
-
-const (
-	conditionTypeThresholdData     conditionType = "thresholdData"
-	conditionTypeDuration          conditionType = "duration"
-	conditionTypeMetric            conditionType = "metric"
-	conditionTypeAggregation       conditionType = "aggregation"
-	conditionTypeThresholdOperator conditionType = "thresholdOperator"
-)
-
-type ConditionMap struct {
-	condition     swoClient.AlertConditionNodeInput
-	conditionType conditionType
-}
+var thresholdOperatorError = errors.New("threshold operation not found")
+var thresholdValueError = errors.New("threshold value not found")
+var aggregationError = errors.New("aggregation operation not found")
 
 // Builds a simple metric condition.
 //
@@ -35,14 +24,19 @@ type ConditionMap struct {
 //	         /    \
 //	Metric Field   10m
 //	    (id=2)    (duration, id=3)
-func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.AlertConditionNodeInput) []swoClient.AlertConditionNodeInput {
+func (model alertConditionModel) toAlertConditionInputs(rootNodeId int) ([]swoClient.AlertConditionNodeInput, error) {
 
-	rootNodeId := 0
-	thresholdOperatorCondition, thresholdDataCondition := model.toThresholdConditionInputs()
+	thresholdOperatorCondition, thresholdDataCondition, err := model.toThresholdConditionInputs()
+	if err != nil {
+		return []swoClient.AlertConditionNodeInput{}, err
+	}
 	thresholdOperatorCondition.Id = rootNodeId
 	thresholdOperatorCondition.OperandIds = []int{rootNodeId + 1, rootNodeId + 4}
 
-	aggregationCondition := model.toAggregationConditionInput()
+	aggregationCondition, err := model.toAggregationConditionInput()
+	if err != nil {
+		return []swoClient.AlertConditionNodeInput{}, err
+	}
 	aggregationCondition.Id = rootNodeId + 1
 	aggregationCondition.OperandIds = []int{rootNodeId + 2, rootNodeId + 3}
 
@@ -54,7 +48,7 @@ func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.A
 
 	thresholdDataCondition.Id = rootNodeId + 4
 
-	conditionsOrdered := []swoClient.AlertConditionNodeInput{
+	conditions := []swoClient.AlertConditionNodeInput{
 		thresholdOperatorCondition,
 		aggregationCondition,
 		metricFieldCondition,
@@ -62,14 +56,14 @@ func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.A
 		thresholdDataCondition,
 	}
 
-	return append(conditions, conditionsOrdered...)
+	return conditions, nil
 }
 
 // Creates the threshold operation and threshold data nodes by either:
 //  1. If model.not_reporting=true, operator is set to '=' and value to '0'
 //  2. Else, parse the model.threshold string into operator and value
 //     Ex:">=3000" -> operator '>=' and value '3000'
-func (model *alertConditionModel) toThresholdConditionInputs() (swoClient.AlertConditionNodeInput, swoClient.AlertConditionNodeInput) {
+func (model alertConditionModel) toThresholdConditionInputs() (swoClient.AlertConditionNodeInput, swoClient.AlertConditionNodeInput, error) {
 	threshold := model.Threshold.ValueString()
 	thresholdOperatorConditions := swoClient.AlertConditionNodeInput{}
 	thresholdDataConditions := swoClient.AlertConditionNodeInput{}
@@ -87,15 +81,16 @@ func (model *alertConditionModel) toThresholdConditionInputs() (swoClient.AlertC
 		thresholdDataConditions.DataType = &dataType
 		thresholdDataConditions.Value = &dataValue
 
-	} else if threshold != "" {
+	} else {
 
-		regex := regexp.MustCompile(`[\W]+`)
+		regex := regexp.MustCompile(`\W+`)
 		operator := regex.FindString(threshold)
 		//Parses threshold into an operator:(>, <, = ...).
 
 		operatorType, err := swoClient.GetAlertConditionType(operator)
 		if err != nil {
-			log.Fatal("Threshold operation not found")
+
+			return thresholdOperatorConditions, thresholdDataConditions, thresholdOperatorError
 		}
 		thresholdOperatorConditions.Type = operatorType
 		thresholdOperatorConditions.Operator = &operator
@@ -111,115 +106,109 @@ func (model *alertConditionModel) toThresholdConditionInputs() (swoClient.AlertC
 			thresholdDataConditions.DataType = &dataType
 			thresholdDataConditions.Value = &thresholdValue
 		} else {
-			log.Fatal("Threshold value not found")
+			return thresholdOperatorConditions, thresholdDataConditions, thresholdValueError
 		}
 	}
 
-	return thresholdOperatorConditions, thresholdDataConditions
+	return thresholdOperatorConditions, thresholdDataConditions, nil
 }
 
-func (model *alertConditionModel) toDurationConditionInput() swoClient.AlertConditionNodeInput {
-	durationCondition := swoClient.AlertConditionNodeInput{}
+func (model alertConditionModel) toDurationConditionInput() swoClient.AlertConditionNodeInput {
 
 	duration := model.Duration.ValueString()
 	dataType := GetStringDataType(duration)
-
-	if duration != "" {
-		durationCondition.Type = string(swoClient.AlertConstantValueType)
-		durationCondition.DataType = &dataType
-		durationCondition.Value = &duration
+	durationCondition := swoClient.AlertConditionNodeInput{
+		Type:     string(swoClient.AlertConstantValueType),
+		DataType: &dataType,
+		Value:    &duration,
 	}
 
 	return durationCondition
 }
 
-func (model *alertConditionModel) toAggregationConditionInput() swoClient.AlertConditionNodeInput {
-	aggregationCondition := swoClient.AlertConditionNodeInput{}
+func (model alertConditionModel) toAggregationConditionInput() (swoClient.AlertConditionNodeInput, error) {
 
 	operator := model.AggregationType.ValueString()
 	operatorType, err := swoClient.GetAlertConditionType(operator)
 	if err != nil {
-		log.Fatal("Aggregation operation not found")
+		return swoClient.AlertConditionNodeInput{}, aggregationError
 	}
 
-	if operator != "" {
-		aggregationCondition.Type = operatorType
-		aggregationCondition.Operator = &operator
+	aggregationCondition := swoClient.AlertConditionNodeInput{
+		Type:     operatorType,
+		Operator: &operator,
 	}
 
-	return aggregationCondition
+	return aggregationCondition, nil
 }
 
-func (model *alertConditionModel) toMetricFieldConditionInput() swoClient.AlertConditionNodeInput {
-	metricFieldCondition := swoClient.AlertConditionNodeInput{}
+func (model alertConditionModel) toMetricFieldConditionInput() swoClient.AlertConditionNodeInput {
+
 	metricName := model.MetricName.ValueString()
+	metricFieldCondition := swoClient.AlertConditionNodeInput{
+		Type:             string(swoClient.AlertMetricFieldType),
+		FieldName:        &metricName,
+		GroupByMetricTag: model.GroupByMetricTag,
+	}
 
-	if metricName != "" {
-		metricFieldCondition = swoClient.AlertConditionNodeInput{
-			Type:             string(swoClient.AlertMetricFieldType),
-			FieldName:        &metricName,
-			GroupByMetricTag: model.GroupByMetricTag,
+	if len(model.EntityIds) > 0 {
+		entityFilter := &swoClient.AlertConditionNodeEntityFilterInput{
+			Types: model.TargetEntityTypes,
+			Ids:   model.EntityIds,
 		}
 
-		if len(model.EntityIds) > 0 {
-			entityFilter := &swoClient.AlertConditionNodeEntityFilterInput{
-				Types: model.TargetEntityTypes,
-				Ids:   model.EntityIds,
-			}
+		metricFieldCondition.EntityFilter = entityFilter
+	}
 
-			metricFieldCondition.EntityFilter = entityFilter
+	var includeTags []alertTagsModel
+	var excludeTags []alertTagsModel
+
+	if model.IncludeTags != nil {
+		includeTags = *model.IncludeTags
+	}
+
+	if model.ExcludeTags != nil {
+		excludeTags = *model.ExcludeTags
+	}
+
+	if len(includeTags) > 0 || len(excludeTags) > 0 {
+		metricFieldCondition.MetricFilter = &swoClient.AlertFilterExpressionInput{
+			Operation: swoClient.FilterOperationAnd,
+		}
+	}
+
+	for _, tag := range includeTags {
+		propertyName := tag.Name.ValueString()
+		metricFilter := swoClient.AlertFilterExpressionInput{
+			PropertyName:   &propertyName,
+			Operation:      swoClient.FilterOperationIn,
+			PropertyValues: tag.Values,
 		}
 
-		var includeTags []alertTagsModel
-		var excludeTags []alertTagsModel
+		metricFieldCondition.MetricFilter.Children = append(
+			metricFieldCondition.MetricFilter.Children,
+			metricFilter,
+		)
+	}
 
-		if model.IncludeTags != nil {
-			includeTags = *model.IncludeTags
+	for _, tag := range excludeTags {
+		propertyName := tag.Name.ValueString()
+		metricFilter := swoClient.AlertFilterExpressionInput{
+			PropertyName:   &propertyName,
+			Operation:      swoClient.FilterOperationIn,
+			PropertyValues: tag.Values,
 		}
 
-		if model.ExcludeTags != nil {
-			excludeTags = *model.ExcludeTags
+		metricFilterNotOp := swoClient.AlertFilterExpressionInput{
+			Operation: swoClient.FilterOperationNot,
 		}
 
-		if len(includeTags) > 0 || len(excludeTags) > 0 {
-			metricFieldCondition.MetricFilter = &swoClient.AlertFilterExpressionInput{
-				Operation: swoClient.FilterOperationAnd,
-			}
-		}
+		metricFilterNotOp.Children = append(metricFilterNotOp.Children, metricFilter)
 
-		for _, tag := range includeTags {
-			propertyName := tag.Name.ValueString()
-			metricFilter := swoClient.AlertFilterExpressionInput{
-				PropertyName:   &propertyName,
-				Operation:      swoClient.FilterOperationIn,
-				PropertyValues: tag.Values,
-			}
-
-			metricFieldCondition.MetricFilter.Children = append(
-				metricFieldCondition.MetricFilter.Children,
-				metricFilter,
-			)
-		}
-
-		for _, tag := range excludeTags {
-			propertyName := tag.Name.ValueString()
-			metricFilter := swoClient.AlertFilterExpressionInput{
-				PropertyName:   &propertyName,
-				Operation:      swoClient.FilterOperationIn,
-				PropertyValues: tag.Values,
-			}
-
-			metricFilterNotOp := swoClient.AlertFilterExpressionInput{
-				Operation: swoClient.FilterOperationNot,
-			}
-
-			metricFilterNotOp.Children = append(metricFilterNotOp.Children, metricFilter)
-
-			metricFieldCondition.MetricFilter.Children = append(
-				metricFieldCondition.MetricFilter.Children,
-				metricFilterNotOp,
-			)
-		}
+		metricFieldCondition.MetricFilter.Children = append(
+			metricFieldCondition.MetricFilter.Children,
+			metricFilterNotOp,
+		)
 	}
 
 	return metricFieldCondition

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -77,6 +77,16 @@ func (r *alertResource) ValidateConfig(ctx context.Context, req resource.Validat
 					"Aggregation type must be COUNT when not_reporting is set to true.",
 				)
 			}
+		} else {
+			threshold := condition.Threshold.ValueString()
+			if threshold == "" {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("threshold"),
+					"Required field when not_reporting is set to false.",
+					"Required field when not_reporting is set to false.",
+				)
+			}
+
 		}
 	}
 }

--- a/internal/provider/alert_resource_test.go
+++ b/internal/provider/alert_resource_test.go
@@ -127,6 +127,74 @@ func TestAccAlertResourceNotReporting(t *testing.T) {
 	})
 }
 
+func TestMultiConditionAlertResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testMultiConditionAlertResourceConfig("test-acc Mock Multi Condition Alert Name"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+
+					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc Mock Multi Condition Alert Name"),
+					resource.TestCheckResourceAttr("swo_alert.test", "description", ""),
+					resource.TestCheckResourceAttr("swo_alert.test", "severity", "INFO"),
+					resource.TestCheckResourceAttr("swo_alert.test", "enabled", "false"),
+					// Verify actions
+					resource.TestCheckResourceAttr("swo_alert.test", "notification_actions.0.configuration_ids.0", "333:email"),
+					resource.TestCheckResourceAttr("swo_alert.test", "notification_actions.0.configuration_ids.1", "444:msteams"),
+					resource.TestCheckResourceAttr("swo_alert.test", "notification_actions.0.resend_interval_seconds", "600"),
+					// Verify number of conditions.
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.#", "3"),
+					// Verify the conditions.
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.target_entity_types.0", "Website"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.metric_name", "sw.metrics.healthscore"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.threshold", "<10"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.not_reporting", "false"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.duration", "5m"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.aggregation_type", "AVG"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.entity_ids.0", "e-1521946194448543744"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.entity_ids.1", "e-1521947552186691584"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.group_by_metric_tag.0", "host.name"),
+
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.target_entity_types.0", "Website"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.metric_name", "synthetics.https.response.time"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.threshold", ">=3000ms"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.not_reporting", "false"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.duration", "5m"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.aggregation_type", "AVG"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.entity_ids.0", "e-1521946194448543744"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.entity_ids.1", "e-1521947552186691584"),
+
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.target_entity_types.0", "Website"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.metric_name", "synthetics.status"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.threshold", ""),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.not_reporting", "true"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.duration", "30m"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.aggregation_type", "COUNT"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.entity_ids.0", "e-1521946194448543744"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.entity_ids.1", "e-1521947552186691584"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.group_by_metric_tag.0", "host.name"),
+
+					resource.TestCheckResourceAttr("swo_alert.test", "notifications.0", "123"),
+					resource.TestCheckResourceAttr("swo_alert.test", "notifications.1", "456"),
+					resource.TestCheckResourceAttr("swo_alert.test", "runbook_link", "https://www.runbooklink.com"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: testMultiConditionAlertResourceConfig("test-acc test_two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc test_two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func testAccAlertResourceConfig(name string) string {
 	return providerConfig() + fmt.Sprintf(`
 
@@ -171,6 +239,73 @@ resource "swo_alert" "test" {
 			"test-service"
 		  ]
 		}]
+	},
+ ]
+ notifications = ["123", "456"]
+ runbook_link = "https://www.runbooklink.com"
+}
+`, name)
+}
+
+func testMultiConditionAlertResourceConfig(name string) string {
+	return providerConfig() + fmt.Sprintf(`
+
+resource "swo_alert" "test" {
+ name        = %[1]q
+ description = ""
+ severity    = "INFO"
+ enabled     = false
+ notification_actions = [
+   {
+	  configuration_ids = ["333:email", "444:msteams"]
+	  resend_interval_seconds = 600
+   },
+ ]
+ conditions = [
+	{
+	  metric_name      = "synthetics.https.response.time"
+	  threshold        = ">=3000ms"
+	  duration         = "5m"
+	  not_reporting    = false
+	  aggregation_type = "AVG"
+	  target_entity_types = ["Website"]
+	  entity_ids = [
+		"e-1521946194448543744",
+		"e-1521947552186691584"
+	  ]
+	  group_by_metric_tag = [
+		"host.name"
+	  ]
+	},
+	{
+	  metric_name      = "sw.metrics.healthscore"
+	  threshold        = "<10"
+	  duration         = "5m"
+	  not_reporting    = false
+	  aggregation_type = "AVG"
+	  target_entity_types = ["Website"]
+	  entity_ids = [
+		"e-1521946194448543744",
+		"e-1521947552186691584"
+	  ]
+	  group_by_metric_tag = [
+		"host.name"
+	  ]
+	},
+	{
+	  metric_name      = "synthetics.status"
+	  threshold        = ""
+	  not_reporting    = true
+	  duration         = "30m"
+	  aggregation_type = "COUNT"
+	  target_entity_types = ["Website"]
+	  entity_ids = [
+		"e-1521946194448543744",
+		"e-1521947552186691584"
+	  ]
+	  group_by_metric_tag = [
+		"host.name"
+	  ]
 	},
  ]
  notifications = ["123", "456"]


### PR DESCRIPTION
There was a gap in the alerting via terraform: it could not support more than 1 metric condition (aka, conditions[].size must == 1).

1. Move not_reporting logic into threshold logic. not_reporting translates to a specific threshold operation and value, and should be treated as such.
2. Remove conditionsMap and funny logic for calculating operandIds. An alert is always the same 5 tree nodes, we can guarantee the operandIds. 
3. Added comments to hopefully better showcase how the condition tree is viewed.
4. Migrate log.Fatal to use diagnostics
5. Added support to transform a list of conditions into a flat tree that is accepted by the alerting API
6. Added unit test
7. Updated alert docs (minor updates from previous schema changes)
8. Migrate log.Fatal to use diagnostics







