### PR TITLE
use diagnostics instead of log.Fatal

### DIFF
--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -8,6 +8,10 @@ import (
 	swoClient "github.com/solarwinds/swo-client-go/pkg/client"
 )
 
+var thresholdOperatorError = errors.New("threshold operation not found")
+var thresholdValueError = errors.New("threshold value not found")
+var aggregationError = errors.New("aggregation operation not found")
+
 // Builds a simple metric condition.
 //
 // An example of a simple metric condition tree:
@@ -85,7 +89,8 @@ func (model alertConditionModel) toThresholdConditionInputs() (swoClient.AlertCo
 
 		operatorType, err := swoClient.GetAlertConditionType(operator)
 		if err != nil {
-			return thresholdOperatorConditions, thresholdDataConditions, errors.New("threshold operation not found")
+
+			return thresholdOperatorConditions, thresholdDataConditions, thresholdOperatorError
 		}
 		thresholdOperatorConditions.Type = operatorType
 		thresholdOperatorConditions.Operator = &operator
@@ -101,7 +106,7 @@ func (model alertConditionModel) toThresholdConditionInputs() (swoClient.AlertCo
 			thresholdDataConditions.DataType = &dataType
 			thresholdDataConditions.Value = &thresholdValue
 		} else {
-			return thresholdOperatorConditions, thresholdDataConditions, errors.New("threshold value not found")
+			return thresholdOperatorConditions, thresholdDataConditions, thresholdValueError
 		}
 	}
 
@@ -126,7 +131,7 @@ func (model alertConditionModel) toAggregationConditionInput() (swoClient.AlertC
 	operator := model.AggregationType.ValueString()
 	operatorType, err := swoClient.GetAlertConditionType(operator)
 	if err != nil {
-		return swoClient.AlertConditionNodeInput{}, errors.New("aggregation operation not found")
+		return swoClient.AlertConditionNodeInput{}, aggregationError
 	}
 
 	aggregationCondition := swoClient.AlertConditionNodeInput{

--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -35,8 +35,9 @@ type ConditionMap struct {
 //	         /    \
 //	Metric Field   10m
 //	    (id=2)    (duration, id=3)
-func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.AlertConditionNodeInput, rootNodeId int) []swoClient.AlertConditionNodeInput {
+func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.AlertConditionNodeInput) []swoClient.AlertConditionNodeInput {
 
+	rootNodeId := 0
 	thresholdOperatorCondition, thresholdDataCondition := model.toThresholdConditionInputs()
 	thresholdOperatorCondition.Id = rootNodeId
 	thresholdOperatorCondition.OperandIds = []int{rootNodeId + 1, rootNodeId + 4}

--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -27,35 +27,31 @@ type ConditionMap struct {
 //
 // An example of a simple metric condition tree:
 //
-//	  							>=
-//					(threshold operator, id=0)
-//	       						/  \
-//	       		 			AVG  	42
-//			(aggregation, id=1)   (threshold data, id=4)
-//	     			/  	\
-//		Metric Field    10m
-//		(id=2) 		   (duration, id=3)
-func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.AlertConditionNodeInput) []swoClient.AlertConditionNodeInput {
+//	                       >=
+//	            (threshold operator, id=0)
+//	                      /  \
+//	                    AVG    42
+//	     (aggregation, id=1)   (threshold data, id=4)
+//	         /    \
+//	Metric Field   10m
+//	    (id=2)    (duration, id=3)
+func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.AlertConditionNodeInput, rootNodeId int) []swoClient.AlertConditionNodeInput {
 
-	rootNode := 0
-	// todo  possible reuse for multi conditions
-	//conditionsReturnedLen := len(conditionMaps)
-	//lastId := len(conditions) + conditionsReturnedLen
 	thresholdOperatorCondition, thresholdDataCondition := model.toThresholdConditionInputs()
-	thresholdOperatorCondition.Id = rootNode
-	thresholdOperatorCondition.OperandIds = []int{rootNode + 1, rootNode + 4}
+	thresholdOperatorCondition.Id = rootNodeId
+	thresholdOperatorCondition.OperandIds = []int{rootNodeId + 1, rootNodeId + 4}
 
 	aggregationCondition := model.toAggregationConditionInput()
-	aggregationCondition.Id = rootNode + 1
-	aggregationCondition.OperandIds = []int{rootNode + 2, rootNode + 3}
+	aggregationCondition.Id = rootNodeId + 1
+	aggregationCondition.OperandIds = []int{rootNodeId + 2, rootNodeId + 3}
 
 	metricFieldCondition := model.toMetricFieldConditionInput()
-	metricFieldCondition.Id = rootNode + 2
+	metricFieldCondition.Id = rootNodeId + 2
 
 	durationCondition := model.toDurationConditionInput()
-	durationCondition.Id = rootNode + 3
+	durationCondition.Id = rootNodeId + 3
 
-	thresholdDataCondition.Id = rootNode + 4
+	thresholdDataCondition.Id = rootNodeId + 4
 
 	conditionsOrdered := []swoClient.AlertConditionNodeInput{
 		thresholdOperatorCondition,
@@ -64,12 +60,12 @@ func (model alertConditionModel) toAlertConditionInputs(conditions []swoClient.A
 		durationCondition,
 		thresholdDataCondition,
 	}
-	// todo keep append to master list we can re-use for multi conditions...
+
 	return append(conditions, conditionsOrdered...)
 }
 
 // Creates the threshold operation and threshold data nodes by either:
-//  1. If not_reporting=true, operator is set to '=' and value to '0'
+//  1. If model.not_reporting=true, operator is set to '=' and value to '0'
 //  2. Else, parse the model.threshold string into operator and value
 //     Ex:">=3000" -> operator '>=' and value '3000'
 func (model *alertConditionModel) toThresholdConditionInputs() (swoClient.AlertConditionNodeInput, swoClient.AlertConditionNodeInput) {

--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -1,19 +1,12 @@
 package provider
 
 import (
-	"log"
+	"errors"
 	"regexp"
 	"strconv"
 
 	swoClient "github.com/solarwinds/swo-client-go/pkg/client"
 )
-
-type conditionType string
-
-type ConditionMap struct {
-	condition     swoClient.AlertConditionNodeInput
-	conditionType conditionType
-}
 
 // Builds a simple metric condition.
 //
@@ -27,13 +20,19 @@ type ConditionMap struct {
 //	         /    \
 //	Metric Field   10m
 //	    (id=2)    (duration, id=3)
-func (model alertConditionModel) toAlertConditionInputs(rootNodeId int) []swoClient.AlertConditionNodeInput {
+func (model alertConditionModel) toAlertConditionInputs(rootNodeId int) ([]swoClient.AlertConditionNodeInput, error) {
 
-	thresholdOperatorCondition, thresholdDataCondition := model.toThresholdConditionInputs()
+	thresholdOperatorCondition, thresholdDataCondition, err := model.toThresholdConditionInputs()
+	if err != nil {
+		return []swoClient.AlertConditionNodeInput{}, err
+	}
 	thresholdOperatorCondition.Id = rootNodeId
 	thresholdOperatorCondition.OperandIds = []int{rootNodeId + 1, rootNodeId + 4}
 
-	aggregationCondition := model.toAggregationConditionInput()
+	aggregationCondition, err := model.toAggregationConditionInput()
+	if err != nil {
+		return []swoClient.AlertConditionNodeInput{}, err
+	}
 	aggregationCondition.Id = rootNodeId + 1
 	aggregationCondition.OperandIds = []int{rootNodeId + 2, rootNodeId + 3}
 
@@ -53,14 +52,14 @@ func (model alertConditionModel) toAlertConditionInputs(rootNodeId int) []swoCli
 		thresholdDataCondition,
 	}
 
-	return conditions
+	return conditions, nil
 }
 
 // Creates the threshold operation and threshold data nodes by either:
 //  1. If model.not_reporting=true, operator is set to '=' and value to '0'
 //  2. Else, parse the model.threshold string into operator and value
 //     Ex:">=3000" -> operator '>=' and value '3000'
-func (model *alertConditionModel) toThresholdConditionInputs() (swoClient.AlertConditionNodeInput, swoClient.AlertConditionNodeInput) {
+func (model alertConditionModel) toThresholdConditionInputs() (swoClient.AlertConditionNodeInput, swoClient.AlertConditionNodeInput, error) {
 	threshold := model.Threshold.ValueString()
 	thresholdOperatorConditions := swoClient.AlertConditionNodeInput{}
 	thresholdDataConditions := swoClient.AlertConditionNodeInput{}
@@ -78,15 +77,15 @@ func (model *alertConditionModel) toThresholdConditionInputs() (swoClient.AlertC
 		thresholdDataConditions.DataType = &dataType
 		thresholdDataConditions.Value = &dataValue
 
-	} else if threshold != "" {
+	} else {
 
-		regex := regexp.MustCompile(`[\W]+`)
+		regex := regexp.MustCompile(`\W+`)
 		operator := regex.FindString(threshold)
 		//Parses threshold into an operator:(>, <, = ...).
 
 		operatorType, err := swoClient.GetAlertConditionType(operator)
 		if err != nil {
-			log.Fatal("Threshold operation not found")
+			return thresholdOperatorConditions, thresholdDataConditions, errors.New("threshold operation not found")
 		}
 		thresholdOperatorConditions.Type = operatorType
 		thresholdOperatorConditions.Operator = &operator
@@ -102,16 +101,14 @@ func (model *alertConditionModel) toThresholdConditionInputs() (swoClient.AlertC
 			thresholdDataConditions.DataType = &dataType
 			thresholdDataConditions.Value = &thresholdValue
 		} else {
-			log.Fatal("Threshold value not found")
+			return thresholdOperatorConditions, thresholdDataConditions, errors.New("threshold value not found")
 		}
-	} else {
-		log.Fatal("Unable to create threshold operation and value")
 	}
 
-	return thresholdOperatorConditions, thresholdDataConditions
+	return thresholdOperatorConditions, thresholdDataConditions, nil
 }
 
-func (model *alertConditionModel) toDurationConditionInput() swoClient.AlertConditionNodeInput {
+func (model alertConditionModel) toDurationConditionInput() swoClient.AlertConditionNodeInput {
 
 	duration := model.Duration.ValueString()
 	dataType := GetStringDataType(duration)
@@ -124,12 +121,12 @@ func (model *alertConditionModel) toDurationConditionInput() swoClient.AlertCond
 	return durationCondition
 }
 
-func (model *alertConditionModel) toAggregationConditionInput() swoClient.AlertConditionNodeInput {
+func (model alertConditionModel) toAggregationConditionInput() (swoClient.AlertConditionNodeInput, error) {
 
 	operator := model.AggregationType.ValueString()
 	operatorType, err := swoClient.GetAlertConditionType(operator)
 	if err != nil {
-		log.Fatal("Aggregation operation not found")
+		return swoClient.AlertConditionNodeInput{}, errors.New("aggregation operation not found")
 	}
 
 	aggregationCondition := swoClient.AlertConditionNodeInput{
@@ -137,10 +134,10 @@ func (model *alertConditionModel) toAggregationConditionInput() swoClient.AlertC
 		Operator: &operator,
 	}
 
-	return aggregationCondition
+	return aggregationCondition, nil
 }
 
-func (model *alertConditionModel) toMetricFieldConditionInput() swoClient.AlertConditionNodeInput {
+func (model alertConditionModel) toMetricFieldConditionInput() swoClient.AlertConditionNodeInput {
 
 	metricName := model.MetricName.ValueString()
 	metricFieldCondition := swoClient.AlertConditionNodeInput{

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -132,15 +132,10 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	// Create the alert from the provided Terraform model...
-	input, err := tfPlan.toAlertDefinitionInput()
-	if err != nil {
-		//	resp.Diagnostics.AddError(
-		//		create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionCreating, ResName{{ .Resource }}, plan.Name.String(), err),
-		//	err.Error(),
-		//)
-
-		resp.Diagnostics.AddError("Client Error",
-			fmt.Sprintf("error creating alert definition '%s'. error: %s", input.Name, err))
+	input, defError := tfPlan.toAlertDefinitionInput()
+	if defError != nil {
+		resp.Diagnostics.AddError("Bad input in terraform resource",
+			fmt.Sprintf("error parsing terraform resource: %s", defError))
 		return
 	}
 
@@ -190,8 +185,8 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	alertId := tfState.Id.ValueString()
 	input, defError := tfPlan.toAlertDefinitionInput()
 	if defError != nil {
-		resp.Diagnostics.AddError("Client Error",
-			fmt.Sprintf("error creating alert definition '%s'. error: %s", input.Name, defError))
+		resp.Diagnostics.AddError("Bad input in terraform resource",
+			fmt.Sprintf("error parsing terraform resource: %s", defError))
 		return
 	}
 


### PR DESCRIPTION
We never want to log.Fatal.

Instead of using log.Fatal, we should use [diagnostics](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics) so that users get meaningful error messages that point to their resource's misconfiguration and not a line in go code somewhere.
