### PR TITLE
fix(website_resource) make rum and availability optional

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -52,7 +52,7 @@ resource "swo_alert" "https_response_time" {
   ]
   notifications         = ["4661:email", "8112:webhook", "2456:newrelic"]
   trigger_reset_actions = true
-  runbookLink           = "https://www.runbook.com/highresponsetime"
+  runbook_link          = "https://www.runbook.com/highresponsetime"
   trigger_delay_seconds = 300
 }
 ```
@@ -73,7 +73,7 @@ resource "swo_alert" "https_response_time" {
 - `notification_actions` (Attributes Set) List of alert notifications that are sent when an alert triggers. (see [below for nested schema](#nestedatt--notification_actions))
 - `notifications` (List of String, Deprecated) A list of notifications that should be triggered for this alert.
 - `runbook_link` (String) A runbook is documentation of what steps to follow when something goes wrong.
-- `trigger_delay_seconds` (Number) Number of seconds during which the conditions must be continually met before an alert is triggered. Value must be between 60 to 86400 seconds, and value has to be divisible by 60.
+- `trigger_delay_seconds` (Number) Number of seconds during which the conditions must be continually met before an alert is triggered. Value must be between 60 to 86400 seconds, and value has to be divisible by 60. Default is `0`.
 - `trigger_reset_actions` (Boolean) True if a notification should be sent when an active alert returns to normal. Default is false. Default is `false`.
 
 ### Read-Only
@@ -88,14 +88,14 @@ Required:
 - `aggregation_type` (String) The aggregation function that will be applied to the metric. Valid values are [`AVG`|`COUNT`|`LAST`|`MAX`|`MIN`|`SUM`].
 - `duration` (String) How long the threshold has been met before triggering an alert.
 - `metric_name` (String) The field name of the metric to be filtered on.
-- `target_entity_types` (List of String) The entity types that the alert will be applied to.
+- `target_entity_types` (List of String) The entity types that the alert will be applied to. Must match across all alert conditions.
 - `threshold` (String) Operator and value that represent the threshold of an the alert. When the threshold is breached it triggers the alert. For Operator - binaryOperator:(=|!=|>|<|>=|<=), logicalOperator:(AND|OR) E.g. '>=10'
 
 Optional:
 
-- `entity_ids` (List of String) A list of Entity IDs that will be used to filter on the alert. The alert will only trigger if the alert matches one or more of the entity IDs.
+- `entity_ids` (List of String) A list of Entity IDs that will be used to filter on the alert. The alert will only trigger if the alert matches one or more of the entity IDs. Must match across all alert conditions.
 - `exclude_tags` (Attributes Set) Tag key and values to match in order to not trigger an alert. (see [below for nested schema](#nestedatt--conditions--exclude_tags))
-- `group_by_metric_tag` (List of String) Group alert data for selected attribute.
+- `group_by_metric_tag` (List of String) Group alert data for selected attribute. Must match across all alert conditions.
 - `include_tags` (Attributes Set) Tag key and values to match in order to trigger an alert. (see [below for nested schema](#nestedatt--conditions--include_tags))
 - `not_reporting` (Boolean) True if the alert should trigger when the metric is not reporting. If true, threshold must be '' and aggregation_type must be 'COUNT'. Default is `false`.
 

--- a/docs/resources/website.md
+++ b/docs/resources/website.md
@@ -58,23 +58,23 @@ resource "swo_website" "test_website" {
         test_from_all = false
         platforms     = ["AWS"]
       }
+
+      custom_headers = [
+        {
+          name  = "Custom-Header-1"
+          value = "Custom-Value-1"
+        },
+        {
+          name  = "Custom-Header-2"
+          value = "Custom-Value-2"
+        }
+      ]
     }
 
     rum = {
       apdex_time_in_seconds = 4
       spa                   = true
     }
-
-    custom_headers = [
-      {
-        name  = "Custom-Header-1"
-        value = "Custom-Value-1"
-      },
-      {
-        name  = "Custom-Header-2"
-        value = "Custom-Value-2"
-      }
-    ]
   }
 }
 ```
@@ -98,7 +98,7 @@ resource "swo_website" "test_website" {
 Optional:
 
 - `availability` (Attributes) The Website availability monitoring settings. (see [below for nested schema](#nestedatt--monitoring--availability))
-- `custom_headers` (Attributes Set, Deprecated) One or more custom headers to send with the uptime check. (see [below for nested schema](#nestedatt--monitoring--custom_headers))
+- `custom_headers` (Attributes Set, Deprecated) One or more custom headers to send with the uptime check. custom_headers has been moved into monitoring.availability. If this field and monitoring.availability.custom_headers are both set an error with be thrown. If this field is set availability must also be set or an error will be thrown. (see [below for nested schema](#nestedatt--monitoring--custom_headers))
 - `options` (Attributes, Deprecated) The Website monitoring options. (see [below for nested schema](#nestedatt--monitoring--options))
 - `rum` (Attributes) The Website RUM monitoring settings. (see [below for nested schema](#nestedatt--monitoring--rum))
 

--- a/docs/resources/website.md
+++ b/docs/resources/website.md
@@ -95,15 +95,11 @@ resource "swo_website" "test_website" {
 <a id="nestedatt--monitoring"></a>
 ### Nested Schema for `monitoring`
 
-Required:
-
-- `availability` (Attributes) The Website availability monitoring settings. (see [below for nested schema](#nestedatt--monitoring--availability))
-- `custom_headers` (Attributes Set) One or more custom headers to send with the uptime check. (see [below for nested schema](#nestedatt--monitoring--custom_headers))
-- `rum` (Attributes) The Website RUM monitoring settings. (see [below for nested schema](#nestedatt--monitoring--rum))
-
 Optional:
 
+- `availability` (Attributes) The Website availability monitoring settings. (see [below for nested schema](#nestedatt--monitoring--availability))
 - `options` (Attributes, Deprecated) The Website monitoring options. (see [below for nested schema](#nestedatt--monitoring--options))
+- `rum` (Attributes) The Website RUM monitoring settings. (see [below for nested schema](#nestedatt--monitoring--rum))
 
 <a id="nestedatt--monitoring--availability"></a>
 ### Nested Schema for `monitoring.availability`
@@ -119,6 +115,7 @@ Required:
 Optional:
 
 - `check_for_string` (Attributes) The Website availability monitoring check for string settings. (see [below for nested schema](#nestedatt--monitoring--availability--check_for_string))
+- `custom_headers` (Attributes Set, Deprecated) One or more custom headers to send with the uptime check. (see [below for nested schema](#nestedatt--monitoring--availability--custom_headers))
 - `ssl` (Attributes) The Website availability monitoring SSL settings. (see [below for nested schema](#nestedatt--monitoring--availability--ssl))
 
 <a id="nestedatt--monitoring--availability--location_options"></a>
@@ -135,7 +132,7 @@ Required:
 
 Required:
 
-- `platforms` (List of String) The Website availability monitoring platform options. Valid values are [AWS, AZURE].
+- `platforms` (List of String) The Website availability monitoring platform options.
 - `test_from_all` (Boolean) Test from all platforms?
 
 
@@ -146,6 +143,15 @@ Required:
 
 - `operator` (String) The Website availability monitoring check for string operator.
 - `value` (String) The Website availability monitoring check for string value.
+
+
+<a id="nestedatt--monitoring--availability--custom_headers"></a>
+### Nested Schema for `monitoring.availability.custom_headers`
+
+Required:
+
+- `name` (String) The Website custom header name.
+- `value` (String) The Website custom header value.
 
 
 <a id="nestedatt--monitoring--availability--ssl"></a>
@@ -159,13 +165,13 @@ Required:
 
 
 
-<a id="nestedatt--monitoring--custom_headers"></a>
-### Nested Schema for `monitoring.custom_headers`
+<a id="nestedatt--monitoring--options"></a>
+### Nested Schema for `monitoring.options`
 
 Required:
 
-- `name` (String) The Website custom header name.
-- `value` (String) The Website custom header value.
+- `is_availability_active` (Boolean, Deprecated) Is availability monitoring active?
+- `is_rum_active` (Boolean, Deprecated) Is RUM monitoring active?
 
 
 <a id="nestedatt--monitoring--rum"></a>
@@ -179,12 +185,3 @@ Required:
 Read-Only:
 
 - `snippet` (String) The Website RUM monitoring code snippet (provided by the server).
-
-
-<a id="nestedatt--monitoring--options"></a>
-### Nested Schema for `monitoring.options`
-
-Required:
-
-- `is_availability_active` (Boolean, Deprecated) Is availability monitoring active?
-- `is_rum_active` (Boolean, Deprecated) Is RUM monitoring active?

--- a/docs/resources/website.md
+++ b/docs/resources/website.md
@@ -98,6 +98,7 @@ resource "swo_website" "test_website" {
 Optional:
 
 - `availability` (Attributes) The Website availability monitoring settings. (see [below for nested schema](#nestedatt--monitoring--availability))
+- `custom_headers` (Attributes Set, Deprecated) One or more custom headers to send with the uptime check. (see [below for nested schema](#nestedatt--monitoring--custom_headers))
 - `options` (Attributes, Deprecated) The Website monitoring options. (see [below for nested schema](#nestedatt--monitoring--options))
 - `rum` (Attributes) The Website RUM monitoring settings. (see [below for nested schema](#nestedatt--monitoring--rum))
 
@@ -115,7 +116,7 @@ Required:
 Optional:
 
 - `check_for_string` (Attributes) The Website availability monitoring check for string settings. (see [below for nested schema](#nestedatt--monitoring--availability--check_for_string))
-- `custom_headers` (Attributes Set, Deprecated) One or more custom headers to send with the uptime check. (see [below for nested schema](#nestedatt--monitoring--availability--custom_headers))
+- `custom_headers` (Attributes Set) One or more custom headers to send with the uptime check. (see [below for nested schema](#nestedatt--monitoring--availability--custom_headers))
 - `ssl` (Attributes) The Website availability monitoring SSL settings. (see [below for nested schema](#nestedatt--monitoring--availability--ssl))
 
 <a id="nestedatt--monitoring--availability--location_options"></a>
@@ -163,6 +164,15 @@ Required:
 - `enabled` (Boolean) Is SSL monitoring enabled?
 - `ignore_intermediate_certificates` (Boolean) Ignore intermediate certificates?
 
+
+
+<a id="nestedatt--monitoring--custom_headers"></a>
+### Nested Schema for `monitoring.custom_headers`
+
+Required:
+
+- `name` (String) The Website custom header name.
+- `value` (String) The Website custom header value.
 
 
 <a id="nestedatt--monitoring--options"></a>

--- a/examples/resources/swo_alert/resource.tf
+++ b/examples/resources/swo_alert/resource.tf
@@ -37,6 +37,6 @@ resource "swo_alert" "https_response_time" {
   ]
   notifications         = ["4661:email", "8112:webhook", "2456:newrelic"]
   trigger_reset_actions = true
-  runbook_link           = "https://www.runbook.com/highresponsetime"
+  runbook_link          = "https://www.runbook.com/highresponsetime"
   trigger_delay_seconds = 300
 }

--- a/examples/resources/swo_website/resource.tf
+++ b/examples/resources/swo_website/resource.tf
@@ -43,22 +43,22 @@ resource "swo_website" "test_website" {
         test_from_all = false
         platforms     = ["AWS"]
       }
+
+      custom_headers = [
+        {
+          name  = "Custom-Header-1"
+          value = "Custom-Value-1"
+        },
+        {
+          name  = "Custom-Header-2"
+          value = "Custom-Value-2"
+        }
+      ]
     }
 
     rum = {
       apdex_time_in_seconds = 4
       spa                   = true
     }
-
-    custom_headers = [
-      {
-        name  = "Custom-Header-1"
-        value = "Custom-Value-1"
-      },
-      {
-        name  = "Custom-Header-2"
-        value = "Custom-Value-2"
-      }
-    ]
   }
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -208,17 +208,17 @@ func New(version string, transport http.RoundTripper) func() provider.Provider {
 	}
 }
 
-func BackoffRetry[T any](ctx context.Context, operation backoff.Operation[T]) (T, error) {
+func BackoffRetry[T any](operation backoff.Operation[T]) (T, error) {
 	expBackoff := backoff.NewExponentialBackOff()
 	expBackoff.MaxInterval = expBackoffMaxInterval
 
-	return backoff.Retry(ctx, operation, backoff.WithBackOff(expBackoff), backoff.WithMaxElapsedTime(expBackoffMaxElapsed))
+	return backoff.Retry(context.Background(), operation, backoff.WithBackOff(expBackoff), backoff.WithMaxElapsedTime(expBackoffMaxElapsed))
 }
 
 func ReadRetry[T any](ctx context.Context, id string, operation ReadOperation[T]) (T, error) {
 	var entity T
 	// Uri, and Website Creates and Updates are eventually consistent. Retry until the entity id is returned.
-	entity, err := BackoffRetry(ctx, func() (T, error) {
+	entity, err := BackoffRetry(func() (T, error) {
 		entity, err := operation(ctx, id)
 		if err != nil {
 			// The entity is still being created, retry

--- a/internal/provider/uri_resource.go
+++ b/internal/provider/uri_resource.go
@@ -154,7 +154,7 @@ func (r *uriResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		tfState.TestDefinitions.TestIntervalInSeconds = types.Int64Null()
 	}
 
-	var locOpts = []uriResourceProbeLocation{}
+	var locOpts []uriResourceProbeLocation
 	for _, x := range testDefs.LocationOptions {
 		locOpts = append(locOpts, uriResourceProbeLocation{
 			Type:  types.StringValue(string(x.Type)),
@@ -251,8 +251,8 @@ func (r *uriResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		return
 	}
 
-	// Updates are eventually consistant. Retry until the URI we read and the URI we are updating match.
-	_, err = BackoffRetry(func() (*swoClient.ReadUriResult, error) {
+	// Updates are eventually consistent. Retry until the URI we read and the URI we are updating match.
+	_, err = BackoffRetry(ctx, func() (*swoClient.ReadUriResult, error) {
 		// Read the Uri...
 		uri, err := r.client.UriService().Read(ctx, tfState.Id.ValueString())
 

--- a/internal/provider/uri_resource.go
+++ b/internal/provider/uri_resource.go
@@ -252,7 +252,7 @@ func (r *uriResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	// Updates are eventually consistent. Retry until the URI we read and the URI we are updating match.
-	_, err = BackoffRetry(ctx, func() (*swoClient.ReadUriResult, error) {
+	_, err = BackoffRetry(func() (*swoClient.ReadUriResult, error) {
 		// Read the Uri...
 		uri, err := r.client.UriService().Read(ctx, tfState.Id.ValueString())
 

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -81,10 +81,6 @@ func sliceToStringList[T any](
 	return list
 }
 
-func stringArrayToList(items []string) types.List {
-	return sliceToStringList(items, func(s string) string { return s })
-}
-
 func attrValueToString(val attr.Value) string {
 	if val == nil {
 		return ""

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -297,19 +297,18 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 			}
 		}
 
-		var customHeaders []swoClient.CustomHeaderInput
-		//monitoring.custom_headers is deprecated. If monitoring.availability.custom_headers is set this will be overridden.
-		if tfPlan.Monitoring.CustomHeaders != nil {
-			customHeaders = convertArray(*tfPlan.Monitoring.CustomHeaders, func(h customHeader) swoClient.CustomHeaderInput {
-				return swoClient.CustomHeaderInput{
-					Name:  h.Name.ValueString(),
-					Value: h.Value.ValueString(),
-				}
-			})
+		var tfPlanCustomHeaders []customHeader
+
+		//monitoring.custom_headers is deprecated. Both custom_headers fields cannot be set at the same time.
+		if tfPlan.Monitoring.Availability.CustomHeaders != nil {
+			tfPlanCustomHeaders = *tfPlan.Monitoring.Availability.CustomHeaders
+		} else {
+			tfPlanCustomHeaders = *tfPlan.Monitoring.CustomHeaders
 		}
 
-		if tfPlan.Monitoring.Availability.CustomHeaders != nil {
-			customHeaders = convertArray(*tfPlan.Monitoring.Availability.CustomHeaders, func(h customHeader) swoClient.CustomHeaderInput {
+		var customHeaders []swoClient.CustomHeaderInput
+		if len(tfPlanCustomHeaders) > 0 {
+			customHeaders = convertArray(tfPlanCustomHeaders, func(h customHeader) swoClient.CustomHeaderInput {
 				return swoClient.CustomHeaderInput{
 					Name:  h.Name.ValueString(),
 					Value: h.Value.ValueString(),

--- a/internal/provider/website_resource_test.go
+++ b/internal/provider/website_resource_test.go
@@ -81,18 +81,6 @@ func testAccWebsiteResourceConfig(name string) string {
 					{
 						type  = "REGION"
 						value = "NA"
-					},
-					{
-						type  = "REGION"
-						value = "AS"
-					},
-					{
-						type  = "REGION"
-						value = "SA"
-					},
-					{
-						type  = "REGION"
-						value = "OC"
 					}
 				]
 	
@@ -100,11 +88,6 @@ func testAccWebsiteResourceConfig(name string) string {
 					test_from_all = false
 					platforms     = ["AWS"]
 				}
-			}
-	
-			rum = {
-				apdex_time_in_seconds = 4
-				spa                   = true
 			}
 	
 			custom_headers = [
@@ -139,18 +122,6 @@ func testAccWebsiteResourceConfigWithoutOptionals(name string) string {
 					{
 						type  = "REGION"
 						value = "NA"
-					},
-					{
-						type  = "REGION"
-						value = "AS"
-					},
-					{
-						type  = "REGION"
-						value = "SA"
-					},
-					{
-						type  = "REGION"
-						value = "OC"
 					}
 				]
 	

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -40,10 +40,10 @@ type sslMonitoring struct {
 }
 
 type websiteMonitoring struct {
-	Options       *monitoringOptions     `tfsdk:"options"`
-	Availability  availabilityMonitoring `tfsdk:"availability"`
-	Rum           rumMonitoring          `tfsdk:"rum"`
-	CustomHeaders []customHeader         `tfsdk:"custom_headers"`
+	Options       *monitoringOptions      `tfsdk:"options"`
+	Availability  *availabilityMonitoring `tfsdk:"availability"`
+	Rum           *rumMonitoring          `tfsdk:"rum"`
+	CustomHeaders []customHeader          `tfsdk:"custom_headers"`
 }
 
 // Deprecated: Options are not used anymore
@@ -211,7 +211,7 @@ func (r *websiteResource) Schema(ctx context.Context, req resource.SchemaRequest
 					},
 					"rum": schema.SingleNestedAttribute{
 						Description: "The Website RUM monitoring settings.",
-						Required:    true,
+						Optional:    true,
 						Attributes: map[string]schema.Attribute{
 							"apdex_time_in_seconds": schema.Int64Attribute{
 								Description: "The Website RUM monitoring apdex time in seconds.",

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -29,8 +29,8 @@ type probeLocation struct {
 }
 
 type platformOptions struct {
-	TestFromAll types.Bool `tfsdk:"test_from_all"`
-	Platforms   types.List `tfsdk:"platforms"`
+	TestFromAll types.Bool     `tfsdk:"test_from_all"`
+	Platforms   []types.String `tfsdk:"platforms"`
 }
 
 type sslMonitoring struct {
@@ -43,7 +43,7 @@ type websiteMonitoring struct {
 	Options       *monitoringOptions      `tfsdk:"options"`
 	Availability  *availabilityMonitoring `tfsdk:"availability"`
 	Rum           *rumMonitoring          `tfsdk:"rum"`
-	CustomHeaders []customHeader          `tfsdk:"custom_headers"`
+	CustomHeaders *[]customHeader         `tfsdk:"custom_headers"` //deprecated
 }
 
 // Deprecated: Options are not used anymore
@@ -60,6 +60,7 @@ type availabilityMonitoring struct {
 	TestIntervalInSeconds types.Int64         `tfsdk:"test_interval_in_seconds"`
 	LocationOptions       []probeLocation     `tfsdk:"location_options"`
 	PlatformOptions       platformOptions     `tfsdk:"platform_options"`
+	CustomHeaders         *[]customHeader     `tfsdk:"custom_headers"`
 }
 
 type rumMonitoring struct {
@@ -114,7 +115,7 @@ func (r *websiteResource) Schema(ctx context.Context, req resource.SchemaRequest
 					},
 					"availability": schema.SingleNestedAttribute{
 						Description: "The Website availability monitoring settings.",
-						Required:    true,
+						Optional:    true,
 						Attributes: map[string]schema.Attribute{
 							"check_for_string": schema.SingleNestedAttribute{
 								Description: "The Website availability monitoring check for string settings.",
@@ -201,9 +202,27 @@ func (r *websiteResource) Schema(ctx context.Context, req resource.SchemaRequest
 										Required:    true,
 									},
 									"platforms": schema.ListAttribute{
-										Description: "The Website availability monitoring platform options. Valid values are [AWS, AZURE].",
+										Description: "The Website availability monitoring platform options.",
 										Required:    true,
 										ElementType: types.StringType,
+									},
+								},
+							},
+							"custom_headers": schema.SetNestedAttribute{
+								Description: "One or more custom headers to send with the uptime check.",
+								Optional:    true,
+								DeprecationMessage: "custom_headers was moved inside of monitoring.availability. " +
+									"Remove this attribute's configuration as it's no longer in use and the attribute will be removed in the next major version of the provider.",
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"name": schema.StringAttribute{
+											Description: "The Website custom header name.",
+											Required:    true,
+										},
+										"value": schema.StringAttribute{
+											Description: "The Website custom header value.",
+											Required:    true,
+										},
 									},
 								},
 							},
@@ -227,22 +246,6 @@ func (r *websiteResource) Schema(ctx context.Context, req resource.SchemaRequest
 							"spa": schema.BoolAttribute{
 								Description: "Is SPA monitoring enabled?",
 								Required:    true,
-							},
-						},
-					},
-					"custom_headers": schema.SetNestedAttribute{
-						Description: "One or more custom headers to send with the uptime check.",
-						Required:    true,
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"name": schema.StringAttribute{
-									Description: "The Website custom header name.",
-									Required:    true,
-								},
-								"value": schema.StringAttribute{
-									Description: "The Website custom header value.",
-									Required:    true,
-								},
 							},
 						},
 					},

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -210,7 +210,7 @@ func (r *websiteResource) Schema(ctx context.Context, req resource.SchemaRequest
 										Required:    true,
 									},
 									"platforms": schema.ListAttribute{
-										Description: "The Website availability monitoring platform options.",
+										Description: "The Website availability monitoring platform options. Valid values are [AWS, AZURE, GOOGLE_CLOUD].",
 										Required:    true,
 										ElementType: types.StringType,
 									},

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -261,8 +261,11 @@ func (r *websiteResource) Schema(ctx context.Context, req resource.SchemaRequest
 						},
 					},
 					"custom_headers": schema.SetNestedAttribute{
-						Description: "One or more custom headers to send with the uptime check.",
-						DeprecationMessage: "custom_headers was moved inside of monitoring.availability. " +
+						Description: "One or more custom headers to send with the uptime check. " +
+							"custom_headers has been moved into monitoring.availability. " +
+							"If this field and monitoring.availability.custom_headers are both set an error with be thrown. " +
+							"If this field is set availability must also be set or an error will be thrown.",
+						DeprecationMessage: "custom_headers has been moved into monitoring.availability. " +
 							"Remove this attribute's configuration as it's no longer in use and the attribute will be removed in the next major version of the provider. " +
 							"If this field and monitoring.availability.custom_headers are both set an error with be thrown. " +
 							"If this field is set availability must also be set or an error will be thrown.",


### PR DESCRIPTION
This makes `rum` and `availability`  optional fields. One type of monitoring still needs to be provided, you will receive and error if both `rum` and `availability` are null.

`rum` and `availability` are both optional in the SWO REST API as well so when we make the transition these fields can stay the same.

`monitoring.custom_headers` has been deprecated. `custom_headers` has been moved to availability to more closely match the `CreateWebsiteInput` instead of `WebsiteMonitoring`. This make it easier to manage the Terraform state.

The SWO REST API  `/v1/dem/websites` website model has `custom_headers` inside of `availability` so this will make the transition to the SWO SDK easier as well. 

Fixes https://github.com/solarwinds/terraform-provider-swo/issues/115

