### PR TITLE
fix(websites) bump swo-client-go version, removing owner from gql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.26.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/joho/godotenv v1.5.1
-	github.com/solarwinds/swo-client-go v0.0.15
+	github.com/solarwinds/swo-client-go v0.0.16
 	github.com/solarwinds/swo-sdk-go/swov1 v0.1.3
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819
 )

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0LY=
 github.com/skeema/knownhosts v1.3.0/go.mod h1:sPINvnADmT/qYH1kfv+ePMmOBTH6Tbl7b5LvTDjFK7M=
-github.com/solarwinds/swo-client-go v0.0.15 h1:wEdYOv7iSibZ1rmr3URIbBIKAg+CMsHr3Zw9TaEVg9o=
-github.com/solarwinds/swo-client-go v0.0.15/go.mod h1:SbUBXaZsLPiIn5w+8xwoAogDW7tbQbTPAbA1YOAxgLE=
+github.com/solarwinds/swo-client-go v0.0.16 h1:siOva7S4TDumYAWU9GSjUEQLjjZB2zxIeI4pqp702lw=
+github.com/solarwinds/swo-client-go v0.0.16/go.mod h1:SbUBXaZsLPiIn5w+8xwoAogDW7tbQbTPAbA1YOAxgLE=
 github.com/solarwinds/swo-sdk-go/swov1 v0.1.3 h1:MigEXIhSjED5qUKCOWV61XDjqw2Sb72KG/AxfD6YDms=
 github.com/solarwinds/swo-sdk-go/swov1 v0.1.3/go.mod h1:a9bcHRcye1qBz3vyZGTlcDg0qndxo9wt9nAuFZhiKrI=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=


### PR DESCRIPTION
Bump swo-client-go to `0.0.16`. This fixes the websites resource GQL by removing owner in favor of ownerId.