### PR TITLE
(feat) alerts add query search to alerting conditions

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -38,6 +38,7 @@ resource "swo_alert" "https_response_time" {
         "e-1521946194448543744",
         "e-1521947552186691584"
       ]
+      query_search = "healthScore.categoryV2:good"
       include_tags = [
         {
           name = "probe.city"
@@ -98,6 +99,7 @@ Optional:
 - `group_by_metric_tag` (List of String) Group alert data for selected attribute. Must match across all alert conditions.
 - `include_tags` (Attributes Set) Tag key and values to match in order to trigger an alert. (see [below for nested schema](#nestedatt--conditions--include_tags))
 - `not_reporting` (Boolean) True if the alert should trigger when the metric is not reporting. If true, threshold must be '' and aggregation_type must be 'COUNT'. Default is `false`.
+- `query_search` (String) Case-sensitive. System will automatically match existing and newly added entities matching the following query string.
 
 <a id="nestedatt--conditions--exclude_tags"></a>
 ### Nested Schema for `conditions.exclude_tags`

--- a/examples/resources/swo_alert/resource.tf
+++ b/examples/resources/swo_alert/resource.tf
@@ -23,6 +23,7 @@ resource "swo_alert" "https_response_time" {
         "e-1521946194448543744",
         "e-1521947552186691584"
       ]
+      query_search = "healthScore.categoryV2:good"
       include_tags = [
         {
           name = "probe.city"

--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -158,15 +158,13 @@ func (model alertConditionModel) toMetricFieldConditionInput(ctx context.Context
 	var entityFilterTypes, entityFilterIds []string
 	model.TargetEntityTypes.ElementsAs(ctx, &entityFilterTypes, false)
 	model.EntityIds.ElementsAs(ctx, &entityFilterIds, false)
-
-	if len(model.EntityIds.Elements()) > 0 {
-		entityFilter := &swoClient.AlertConditionNodeEntityFilterInput{
-			Types: entityFilterTypes,
-			Ids:   entityFilterIds,
-		}
-
-		metricFieldCondition.EntityFilter = entityFilter
+	querySearch := model.QuerySearch.ValueString()
+	entityFilter := &swoClient.AlertConditionNodeEntityFilterInput{
+		Types: entityFilterTypes,
+		Ids:   entityFilterIds,
+		Query: &querySearch,
 	}
+	metricFieldCondition.EntityFilter = entityFilter
 
 	var includeTags []alertTagsModel
 	var excludeTags []alertTagsModel

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -115,6 +115,13 @@ func (model *alertResourceModel) validateConditions() diag.Diagnostics {
 				fmt.Sprintf("The list must be same for all conditions, but %v does not match %v.", firstNode.EntityIds, condition.EntityIds))
 			conditionErrors = append(conditionErrors, d)
 		}
+		if !firstNode.QuerySearch.Equal(condition.QuerySearch) {
+			d := diag.NewAttributeErrorDiagnostic(
+				path.Root("querySearch"),
+				"Query search must be same for all conditions",
+				fmt.Sprintf("Query search must be the same for all conditions, but %v does not match %v.", firstNode.QuerySearch, condition.QuerySearch))
+			conditionErrors = append(conditionErrors, d)
+		}
 		if !firstNode.GroupByMetricTag.Equal(condition.GroupByMetricTag) {
 			d := diag.NewAttributeErrorDiagnostic(
 				path.Root("groupByMetricTag"),

--- a/internal/provider/alert_resource_acc_test.go
+++ b/internal/provider/alert_resource_acc_test.go
@@ -37,6 +37,7 @@ func TestAccAlertResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.aggregation_type", "AVG"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.entity_ids.0", "e-1521946194448543744"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.entity_ids.1", "e-1521947552186691584"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.query_search", "healthScore.categoryV2:bad"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.group_by_metric_tag.0", "host.name"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.include_tags.0.name", "probe.city"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.include_tags.0.values.0", "Tokyo"),
@@ -159,6 +160,7 @@ func TestMultiConditionAlertResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.aggregation_type", "AVG"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.entity_ids.0", "e-1521946194448543744"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.entity_ids.1", "e-1521947552186691584"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.query_search", "healthScore.categoryV2:bad"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.group_by_metric_tag.0", "host.name"),
 
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.target_entity_types.0", "Website"),
@@ -169,6 +171,7 @@ func TestMultiConditionAlertResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.aggregation_type", "AVG"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.entity_ids.0", "e-1521946194448543744"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.entity_ids.1", "e-1521947552186691584"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.query_search", "healthScore.categoryV2:bad"),
 
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.target_entity_types.0", "Website"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.metric_name", "synthetics.status"),
@@ -178,6 +181,7 @@ func TestMultiConditionAlertResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.aggregation_type", "COUNT"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.entity_ids.0", "e-1521946194448543744"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.entity_ids.1", "e-1521947552186691584"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.query_search", "healthScore.categoryV2:bad"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.group_by_metric_tag.0", "host.name"),
 
 					resource.TestCheckResourceAttr("swo_alert.test", "notifications.0", "123"),
@@ -224,6 +228,7 @@ resource "swo_alert" "test" {
 		"e-1521946194448543744",
 		"e-1521947552186691584"
 	  ]
+      query_search = "healthScore.categoryV2:bad"
 	  group_by_metric_tag = [
 		"host.name"
 	  ]
@@ -277,6 +282,7 @@ resource "swo_alert" "test" {
 		"e-1521946194448543744",
 		"e-1521947552186691584"
 	  ]
+      query_search = "healthScore.categoryV2:bad"
 	  group_by_metric_tag = [
 		"host.name"
 	  ]
@@ -292,6 +298,7 @@ resource "swo_alert" "test" {
 		"e-1521946194448543744",
 		"e-1521947552186691584"
 	  ]
+      query_search = "healthScore.categoryV2:bad"
 	  group_by_metric_tag = [
 		"host.name"
 	  ]
@@ -307,6 +314,7 @@ resource "swo_alert" "test" {
 		"e-1521946194448543744",
 		"e-1521947552186691584"
 	  ]
+      query_search = "healthScore.categoryV2:bad"
 	  group_by_metric_tag = [
 		"host.name"
 	  ]

--- a/internal/provider/alert_resource_unit_test.go
+++ b/internal/provider/alert_resource_unit_test.go
@@ -146,6 +146,8 @@ func Test_ValidateCondition_CompareLists(t *testing.T) {
 	tags0 := []attr.Value{types.StringValue("tags.names")}
 	groupByMetricTag0, _ := types.ListValue(types.StringType, tags0)
 
+	query0 := types.StringValue("healthScore.categoryV2:bad")
+
 	entities1 := []attr.Value{types.StringValue("Uri")}
 	targetEntityTypes1, _ := types.ListValue(types.StringType, entities1)
 
@@ -155,6 +157,8 @@ func Test_ValidateCondition_CompareLists(t *testing.T) {
 	tags1 := []attr.Value{types.StringValue("tags.environment")}
 	groupByMetricTag1, _ := types.ListValue(types.StringType, tags1)
 
+	query1 := types.StringValue("healthScore.categoryV2:good")
+
 	model := alertResourceModel{
 		Conditions: []alertConditionModel{
 			{
@@ -163,6 +167,7 @@ func Test_ValidateCondition_CompareLists(t *testing.T) {
 				AggregationType:   types.StringValue("AVG"),
 				TargetEntityTypes: targetEntityTypes0,
 				EntityIds:         entityIds0,
+				QuerySearch:       query0,
 				GroupByMetricTag:  groupByMetricTag0,
 			},
 			{
@@ -172,6 +177,7 @@ func Test_ValidateCondition_CompareLists(t *testing.T) {
 				// same []types.List as node 0
 				TargetEntityTypes: targetEntityTypes0,
 				EntityIds:         entityIds0,
+				QuerySearch:       query0,
 				GroupByMetricTag:  groupByMetricTag0,
 			},
 			{
@@ -181,6 +187,7 @@ func Test_ValidateCondition_CompareLists(t *testing.T) {
 				// different []types.List from node 0
 				TargetEntityTypes: targetEntityTypes1,
 				EntityIds:         entityIds1,
+				QuerySearch:       query1,
 				GroupByMetricTag:  groupByMetricTag1,
 			},
 		},
@@ -196,6 +203,10 @@ func Test_ValidateCondition_CompareLists(t *testing.T) {
 			path.Root("entityIds"),
 			"The list must be same for all conditions",
 			"The list must be same for all conditions, but [\"123\"] does not match [\"456\"]."),
+		diag.NewAttributeErrorDiagnostic(
+			path.Root("querySearch"),
+			"Query search must be same for all conditions",
+			"Query search must be the same for all conditions, but \"healthScore.categoryV2:bad\" does not match \"healthScore.categoryV2:good\"."),
 		diag.NewAttributeErrorDiagnostic(
 			path.Root("groupByMetricTag"),
 			"The list must be same for all conditions",

--- a/internal/provider/alert_schema.go
+++ b/internal/provider/alert_schema.go
@@ -35,6 +35,7 @@ type alertConditionModel struct {
 	Duration          types.String      `tfsdk:"duration"`
 	AggregationType   types.String      `tfsdk:"aggregation_type"`
 	EntityIds         types.List        `tfsdk:"entity_ids"`
+	QuerySearch       types.String      `tfsdk:"query_search"`
 	TargetEntityTypes types.List        `tfsdk:"target_entity_types"`
 	IncludeTags       *[]alertTagsModel `tfsdk:"include_tags"`
 	ExcludeTags       *[]alertTagsModel `tfsdk:"exclude_tags"`
@@ -161,6 +162,11 @@ func (r *alertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Description: "A list of Entity IDs that will be used to filter on the alert. The alert will only trigger if the alert matches one or more of the entity IDs. Must match across all alert conditions.",
 							Optional:    true,
 							ElementType: types.StringType,
+						},
+						"query_search": schema.StringAttribute{
+							Description: "Case-sensitive. System will automatically match existing and newly added " +
+								"entities matching the following query string.",
+							Optional: true,
 						},
 						"target_entity_types": schema.ListAttribute{
 							Description: "The entity types that the alert will be applied to. Must match across all alert conditions.",


### PR DESCRIPTION
Add support for query search in alerting conditions. Search is case-sensitive. System will automatically match existing and newly added entities that contain the query to the alerting condition. Validation of query string is not performed by TF, rather the alerting API will provide feedback/error messaging on invalid syntax. 

1. In conditions model, add new optional field `query_search` (string)
2. Map `query_search` to the `metricField` node which contains the `entityFilter`

```
"entityFilter": {
    "types": ["Website"],
     "query": "healthScore.categoryV2:bad healthScore.scoreV2:100 features:rum"
    }
 }
```

 