### PR TITLE
TF enforces validation handling for dynamic underlying null values

### DIFF
--- a/internal/provider/alert_conditions.go
+++ b/internal/provider/alert_conditions.go
@@ -168,14 +168,8 @@ func (model alertConditionModel) toMetricFieldConditionInput(ctx context.Context
 
 	var includeTags []alertTagsModel
 	var excludeTags []alertTagsModel
-
-	if model.IncludeTags != nil {
-		includeTags = *model.IncludeTags
-	}
-
-	if model.ExcludeTags != nil {
-		excludeTags = *model.ExcludeTags
-	}
+	model.IncludeTags.ElementsAs(ctx, &includeTags, false)
+	model.ExcludeTags.ElementsAs(ctx, &excludeTags, false)
 
 	if len(includeTags) > 0 || len(excludeTags) > 0 {
 		metricFieldCondition.MetricFilter = &swoClient.AlertFilterExpressionInput{

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -318,13 +318,16 @@ func (model *alertResourceModel) toAlertDefinitionInput(ctx context.Context) (sw
 func (model *alertResourceModel) toAlertActionInput(ctx context.Context) []swoClient.AlertActionInput {
 	var inputs []swoClient.AlertActionInput
 
+	var notificationActions []alertActionInputModel
+	model.NotificationActions.ElementsAs(ctx, &notificationActions, false)
+
 	//Notifications is deprecated. NotificationActions should be used instead.
 	// This if/else maintains backwards compatability.
-	if len(model.NotificationActions) > 0 {
+	if len(notificationActions) > 0 {
 		receivingType := swoClient.NotificationReceivingTypeNotSpecified
 		includeDetails := true
 
-		for _, action := range model.NotificationActions {
+		for _, action := range notificationActions {
 			actionsList := make(map[string][]string)
 
 			var configurationIds []string

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -48,18 +48,18 @@ func (r *alertResource) ValidateConfig(ctx context.Context, req resource.Validat
 }
 
 func (model *alertResourceModel) validateConditions(ctx context.Context) diag.Diagnostics {
-	var planConditions []alertConditionModel
-	d := model.Conditions.ElementsAs(ctx, &planConditions, false)
-	if d.HasError() {
-		return d
-	}
-
-	if len(planConditions) > 5 || len(planConditions) < 1 {
+	if len(model.Conditions.Elements()) > 5 || len(model.Conditions.Elements()) < 1 {
 		return diag.Diagnostics{
 			diag.NewAttributeErrorDiagnostic(
 				path.Root("conditions"),
 				"Invalid number of alerting conditions.",
 				"Number of alerting conditions must be between 1 and 5.")}
+	}
+
+	var planConditions []alertConditionModel
+	d := model.Conditions.ElementsAs(ctx, &planConditions, false)
+	if d.HasError() {
+		return d
 	}
 
 	// validate each alert condition

--- a/internal/provider/alert_schema.go
+++ b/internal/provider/alert_schema.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -16,17 +17,17 @@ import (
 
 // The main Alert Resource model that is derived from the schema.
 type alertResourceModel struct {
-	Id                  types.String          `tfsdk:"id"`
-	Name                types.String          `tfsdk:"name"`
-	NotificationActions types.Set             `tfsdk:"notification_actions"`
-	Description         types.String          `tfsdk:"description"`
-	Severity            types.String          `tfsdk:"severity"`
-	Enabled             types.Bool            `tfsdk:"enabled"`
-	Conditions          []alertConditionModel `tfsdk:"conditions"`
-	Notifications       types.List            `tfsdk:"notifications"`
-	TriggerResetActions types.Bool            `tfsdk:"trigger_reset_actions"`
-	RunbookLink         types.String          `tfsdk:"runbook_link"`
-	TriggerDelaySeconds types.Int64           `tfsdk:"trigger_delay_seconds"`
+	Id                  types.String `tfsdk:"id"`
+	Name                types.String `tfsdk:"name"`
+	NotificationActions types.Set    `tfsdk:"notification_actions"` //alertActionInputModel
+	Description         types.String `tfsdk:"description"`
+	Severity            types.String `tfsdk:"severity"`
+	Enabled             types.Bool   `tfsdk:"enabled"`
+	Conditions          types.Set    `tfsdk:"conditions"` //alertConditionModel
+	Notifications       types.List   `tfsdk:"notifications"`
+	TriggerResetActions types.Bool   `tfsdk:"trigger_reset_actions"`
+	RunbookLink         types.String `tfsdk:"runbook_link"`
+	TriggerDelaySeconds types.Int64  `tfsdk:"trigger_delay_seconds"`
 }
 
 type alertConditionModel struct {
@@ -43,9 +44,32 @@ type alertConditionModel struct {
 	NotReporting      types.Bool   `tfsdk:"not_reporting"`
 }
 
+func AlertConditionAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"metric_name":         types.StringType,
+		"threshold":           types.StringType,
+		"duration":            types.StringType,
+		"aggregation_type":    types.StringType,
+		"entity_ids":          types.ListType{ElemType: types.StringType},
+		"query_search":        types.StringType,
+		"target_entity_types": types.ListType{ElemType: types.StringType},
+		"include_tags":        types.SetType{ElemType: types.ObjectType{AttrTypes: AlertTagAttributeTypes()}},
+		"exclude_tags":        types.SetType{ElemType: types.ObjectType{AttrTypes: AlertTagAttributeTypes()}},
+		"group_by_metric_tag": types.ListType{ElemType: types.StringType},
+		"not_reporting":       types.BoolType,
+	}
+}
+
 type alertTagsModel struct {
 	Name   types.String `tfsdk:"name"`
 	Values types.List   `tfsdk:"values"`
+}
+
+func AlertTagAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":  types.StringType,
+		"value": types.ListType{ElemType: types.StringType},
+	}
 }
 
 type alertActionInputModel struct {

--- a/internal/provider/alert_schema.go
+++ b/internal/provider/alert_schema.go
@@ -16,17 +16,17 @@ import (
 
 // The main Alert Resource model that is derived from the schema.
 type alertResourceModel struct {
-	Id                  types.String            `tfsdk:"id"`
-	Name                types.String            `tfsdk:"name"`
-	NotificationActions []alertActionInputModel `tfsdk:"notification_actions"`
-	Description         types.String            `tfsdk:"description"`
-	Severity            types.String            `tfsdk:"severity"`
-	Enabled             types.Bool              `tfsdk:"enabled"`
-	Conditions          []alertConditionModel   `tfsdk:"conditions"`
-	Notifications       types.List              `tfsdk:"notifications"`
-	TriggerResetActions types.Bool              `tfsdk:"trigger_reset_actions"`
-	RunbookLink         types.String            `tfsdk:"runbook_link"`
-	TriggerDelaySeconds types.Int64             `tfsdk:"trigger_delay_seconds"`
+	Id                  types.String          `tfsdk:"id"`
+	Name                types.String          `tfsdk:"name"`
+	NotificationActions types.Set             `tfsdk:"notification_actions"`
+	Description         types.String          `tfsdk:"description"`
+	Severity            types.String          `tfsdk:"severity"`
+	Enabled             types.Bool            `tfsdk:"enabled"`
+	Conditions          []alertConditionModel `tfsdk:"conditions"`
+	Notifications       types.List            `tfsdk:"notifications"`
+	TriggerResetActions types.Bool            `tfsdk:"trigger_reset_actions"`
+	RunbookLink         types.String          `tfsdk:"runbook_link"`
+	TriggerDelaySeconds types.Int64           `tfsdk:"trigger_delay_seconds"`
 }
 
 type alertConditionModel struct {

--- a/internal/provider/alert_schema.go
+++ b/internal/provider/alert_schema.go
@@ -30,17 +30,17 @@ type alertResourceModel struct {
 }
 
 type alertConditionModel struct {
-	MetricName        types.String      `tfsdk:"metric_name"`
-	Threshold         types.String      `tfsdk:"threshold"`
-	Duration          types.String      `tfsdk:"duration"`
-	AggregationType   types.String      `tfsdk:"aggregation_type"`
-	EntityIds         types.List        `tfsdk:"entity_ids"`
-	QuerySearch       types.String      `tfsdk:"query_search"`
-	TargetEntityTypes types.List        `tfsdk:"target_entity_types"`
-	IncludeTags       *[]alertTagsModel `tfsdk:"include_tags"`
-	ExcludeTags       *[]alertTagsModel `tfsdk:"exclude_tags"`
-	GroupByMetricTag  types.List        `tfsdk:"group_by_metric_tag"`
-	NotReporting      types.Bool        `tfsdk:"not_reporting"`
+	MetricName        types.String `tfsdk:"metric_name"`
+	Threshold         types.String `tfsdk:"threshold"`
+	Duration          types.String `tfsdk:"duration"`
+	AggregationType   types.String `tfsdk:"aggregation_type"`
+	EntityIds         types.List   `tfsdk:"entity_ids"`
+	QuerySearch       types.String `tfsdk:"query_search"`
+	TargetEntityTypes types.List   `tfsdk:"target_entity_types"`
+	IncludeTags       types.Set    `tfsdk:"include_tags"`
+	ExcludeTags       types.Set    `tfsdk:"exclude_tags"`
+	GroupByMetricTag  types.List   `tfsdk:"group_by_metric_tag"`
+	NotReporting      types.Bool   `tfsdk:"not_reporting"`
 }
 
 type alertTagsModel struct {

--- a/internal/provider/api_token_resource.go
+++ b/internal/provider/api_token_resource.go
@@ -165,12 +165,14 @@ func AttributesToTerraform(result *swoClient.ReadApiTokenResult) (types.Set, dia
 	var diags diag.Diagnostics
 	var elements []attr.Value
 
+	var attributeTypes = map[string]attr.Type{
+		"key":   types.StringType,
+		"value": types.StringType,
+	}
+
 	for _, attribute := range result.Attributes {
 		objectValue, objectDiags := types.ObjectValue(
-			map[string]attr.Type{
-				"key":   types.StringType,
-				"value": types.StringType,
-			},
+			attributeTypes,
 			map[string]attr.Value{
 				"key":   types.StringValue(attribute.Key),
 				"value": types.StringValue(attribute.Value),
@@ -180,10 +182,7 @@ func AttributesToTerraform(result *swoClient.ReadApiTokenResult) (types.Set, dia
 		diags = append(diags, objectDiags...)
 	}
 
-	setValue, setDiags := types.SetValue(types.ObjectType{AttrTypes: map[string]attr.Type{
-		"key":   types.StringType,
-		"value": types.StringType,
-	}}, elements)
+	setValue, setDiags := types.SetValue(types.ObjectType{AttrTypes: attributeTypes}, elements)
 	diags = append(diags, setDiags...)
 
 	return setValue, diags

--- a/internal/provider/api_token_resource.go
+++ b/internal/provider/api_token_resource.go
@@ -50,7 +50,7 @@ func (r *apiTokenResource) Create(ctx context.Context, req resource.CreateReques
 	// Create our input request.
 	createInput := swoClient.CreateTokenInput{
 		Name:        tfPlan.Name.ValueString(),
-		AccessLevel: *tfPlan.AccessLevel,
+		AccessLevel: swoClient.TokenAccessLevel(tfPlan.AccessLevel.ValueString()),
 		Type:        tfPlan.Type.ValueStringPointer(),
 		Attributes: convertArray(attributes, func(v apiTokenAttribute) swoClient.TokenAttributeInput {
 			return swoClient.TokenAttributeInput{
@@ -111,7 +111,7 @@ func (r *apiTokenResource) Update(ctx context.Context, req resource.UpdateReques
 		Name:        tfPlan.Name.ValueStringPointer(),
 		Enabled:     tfPlan.Enabled.ValueBoolPointer(),
 		Type:        tfPlan.Type.ValueStringPointer(),
-		AccessLevel: tfPlan.AccessLevel,
+		AccessLevel: (*swoClient.TokenAccessLevel)(tfPlan.AccessLevel.ValueStringPointer()),
 		Attributes: convertArray(attributes, func(v apiTokenAttribute) swoClient.TokenAttributeInput {
 			return swoClient.TokenAttributeInput{
 				Key:   v.Key.ValueString(),
@@ -155,7 +155,7 @@ func (r *apiTokenResource) updateState(state *apiTokenResourceModel, result *swo
 	state.Name = types.StringPointerValue(result.Name)
 	state.Enabled = types.BoolPointerValue(result.Enabled)
 	state.Type = types.StringPointerValue(result.Type)
-	state.AccessLevel = result.AccessLevel
+	state.AccessLevel = types.StringValue(string(*result.AccessLevel))
 
 	attributes, _ := AttributesToTerraform(result)
 	state.Attributes = attributes

--- a/internal/provider/api_token_resource_test.go
+++ b/internal/provider/api_token_resource_test.go
@@ -19,6 +19,11 @@ func TestAccApiTokenResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("swo_apitoken.test", "id"),
 					resource.TestCheckResourceAttr("swo_apitoken.test", "name", "test-acc test one"),
+					resource.TestCheckResourceAttr("swo_apitoken.test", "access_level", "API_FULL"),
+					resource.TestCheckResourceAttr("swo_apitoken.test", "type", "public-api"),
+					resource.TestCheckResourceAttr("swo_apitoken.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("swo_apitoken.test", "attributes.0.key", "attribute-key"),
+					resource.TestCheckResourceAttr("swo_apitoken.test", "attributes.0.value", "attribute value"),
 				),
 			},
 			// ImportState testing

--- a/internal/provider/api_token_schema.go
+++ b/internal/provider/api_token_schema.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 
 	"github.com/solarwinds/terraform-provider-swo/internal/validators"
 
@@ -31,6 +32,13 @@ type apiTokenResourceModel struct {
 type apiTokenAttribute struct {
 	Key   types.String `tfsdk:"key"`
 	Value types.String `tfsdk:"value"`
+}
+
+func TokenAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"key":   types.StringType,
+		"value": types.StringType,
+	}
 }
 
 func (r *apiTokenResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/provider/api_token_schema.go
+++ b/internal/provider/api_token_schema.go
@@ -18,13 +18,13 @@ import (
 
 // apiTokenResourceModel is the main resource model.
 type apiTokenResourceModel struct {
-	Id          types.String                `tfsdk:"id"`
-	Name        types.String                `tfsdk:"name"`
-	Enabled     types.Bool                  `tfsdk:"enabled"`
-	Type        types.String                `tfsdk:"type"`
-	Token       types.String                `tfsdk:"token"`
-	AccessLevel *swoClient.TokenAccessLevel `tfsdk:"access_level"`
-	Attributes  types.Set                   `tfsdk:"attributes"`
+	Id          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	Type        types.String `tfsdk:"type"`
+	Token       types.String `tfsdk:"token"`
+	AccessLevel types.String `tfsdk:"access_level"`
+	Attributes  types.Set    `tfsdk:"attributes"`
 }
 
 // apiTokenAttribute is a custom attribute for the ApiTokenResourceModel.

--- a/internal/provider/api_token_schema.go
+++ b/internal/provider/api_token_schema.go
@@ -24,7 +24,7 @@ type apiTokenResourceModel struct {
 	Type        types.String                `tfsdk:"type"`
 	Token       types.String                `tfsdk:"token"`
 	AccessLevel *swoClient.TokenAccessLevel `tfsdk:"access_level"`
-	Attributes  []apiTokenAttribute         `tfsdk:"attributes"`
+	Attributes  types.Set                   `tfsdk:"attributes"`
 }
 
 // apiTokenAttribute is a custom attribute for the ApiTokenResourceModel.

--- a/internal/provider/composite_metric_resource_test.go
+++ b/internal/provider/composite_metric_resource_test.go
@@ -33,10 +33,13 @@ func TestAccCompositeMetricResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccCompositeMetricResourceConfig("composite.testacc", "display name two"),
+				Config: testAccCompositeUpdateMetricResourceConfig("composite.testacc", "display name two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", "composite.testacc"),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "display_name", "display name two"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "description", "Update metric description"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "SUM(synthetics.https.response.time)"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "unit", "m/s"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -52,5 +55,16 @@ func testAccCompositeMetricResourceConfig(name string, displayName string) strin
 		description = "test-acc composite metric description"
 		formula = "rate(system.disk.io[5m])"
 		unit = "bytes/s"
+	}`, name, displayName)
+}
+
+func testAccCompositeUpdateMetricResourceConfig(name string, displayName string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_compositemetric" "test" {
+		name        = %[1]q
+		display_name = %[2]q
+		description = "Update metric description"
+		formula = "SUM(synthetics.https.response.time)"
+		unit = "m/s"
 	}`, name, displayName)
 }

--- a/internal/provider/dashboard_resource.go
+++ b/internal/provider/dashboard_resource.go
@@ -52,12 +52,16 @@ func (r *dashboardResource) Configure(ctx context.Context, req resource.Configur
 }
 
 // Creates new WidgetInputs and LayoutInputs from plan widget data.
-func widgetsFromPlan(plan dashboardResourceModel) ([]swoClient.WidgetInput, []swoClient.LayoutInput, error) {
-	widgets := make([]swoClient.WidgetInput, len(plan.Widgets))
-	layouts := make([]swoClient.LayoutInput, len(plan.Widgets))
+func widgetsFromPlan(ctx context.Context, plan dashboardResourceModel) ([]swoClient.WidgetInput, []swoClient.LayoutInput, error) {
 
-	for wIdx := range plan.Widgets {
-		planW := &plan.Widgets[wIdx]
+	var planWidgets []dashboardWidgetModel
+	plan.Widgets.ElementsAs(ctx, &planWidgets, false)
+
+	widgets := make([]swoClient.WidgetInput, len(planWidgets))
+	layouts := make([]swoClient.LayoutInput, len(planWidgets))
+
+	for wIdx := range planWidgets {
+		planW := &planWidgets[wIdx]
 		id := uuid.NewString()
 
 		// Marshal the json encoded properties string to an object.
@@ -86,8 +90,11 @@ func widgetsFromPlan(plan dashboardResourceModel) ([]swoClient.WidgetInput, []sw
 }
 
 // Sets the computed values of the dashboard models with the values returned from the Create request.
-func setDashboardValuesFromCreate(dashboard *swoClient.CreateDashboardResult, plan *dashboardResourceModel) error {
+func setDashboardValuesFromCreate(ctx context.Context, dashboard *swoClient.CreateDashboardResult, plan *dashboardResourceModel) error {
 	plan.Id = types.StringValue(dashboard.Id)
+
+	var planWidgets []dashboardWidgetModel
+	plan.Widgets.ElementsAs(ctx, &planWidgets, false)
 
 	for _, w := range dashboard.Widgets {
 		lIdx := slices.IndexFunc(dashboard.Layout, func(l swoClient.CreateDashboardLayout) bool { return l.Id == w.Id })
@@ -99,27 +106,29 @@ func setDashboardValuesFromCreate(dashboard *swoClient.CreateDashboardResult, pl
 		layout := &dashboard.Layout[lIdx]
 
 		// We need to compare the properties of the plan widget with what is returned from the server
-		// to reconcile the server data with the plan data. Widgets ids in the plan are temporary and
+		// to reconcile the server data with the plan data. A widget's id in the plan is temporary, and
 		// there isn't any single value we can use to make a match.
-		for wIdx := range plan.Widgets {
-			planW := &plan.Widgets[wIdx]
+		for wIdx := range planWidgets {
+			planW := &planWidgets[wIdx]
 			if planW.Type.Equal(types.StringValue(w.Type)) &&
 				planW.X.Equal(types.Int64Value(int64(layout.X))) &&
 				planW.Y.Equal(types.Int64Value(int64(layout.Y))) &&
 				planW.Width.Equal(types.Int64Value(int64(layout.Width))) &&
 				planW.Height.Equal(types.Int64Value(int64(layout.Height))) {
-				// Widget properties are equal so we assume it must be the one we're looking for.
+				// Widget properties are equal, so we assume it must be the one we're looking for.
 				planW.Id = types.StringValue(w.Id)
 				break
 			}
 		}
 	}
 
+	updatedWidgets, _ := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: WidgetAttributeTypes()}, planWidgets)
+	plan.Widgets = updatedWidgets
 	return nil
 }
 
 // Sets the values of the terraform state with the values returned from the Read request.
-func setDashboardValuesFromRead(dashboard *swoClient.ReadDashboardResult, state *dashboardResourceModel) error {
+func setDashboardValuesFromRead(ctx context.Context, dashboard *swoClient.ReadDashboardResult, state *dashboardResourceModel) error {
 	state.Id = types.StringValue(dashboard.Id)
 	state.Name = types.StringValue(dashboard.Name)
 	if dashboard.Category != nil {
@@ -128,6 +137,9 @@ func setDashboardValuesFromRead(dashboard *swoClient.ReadDashboardResult, state 
 	if dashboard.IsPrivate != nil {
 		state.IsPrivate = types.BoolValue(*dashboard.IsPrivate)
 	}
+
+	var stateWidgets []dashboardWidgetModel
+	state.Widgets.ElementsAs(ctx, &stateWidgets, false)
 
 	for _, w := range dashboard.Widgets {
 		lIdx := slices.IndexFunc(dashboard.Layout, func(l swoClient.ReadDashboardLayout) bool { return l.Id == w.Id })
@@ -143,8 +155,8 @@ func setDashboardValuesFromRead(dashboard *swoClient.ReadDashboardResult, state 
 			return newWidgetPropertiesError(err.Error(), w.Id)
 		}
 
-		for wIdx := range state.Widgets {
-			stateW := &state.Widgets[wIdx]
+		for wIdx := range stateWidgets {
+			stateW := &stateWidgets[wIdx]
 			if stateW.Id.Equal(types.StringValue(w.Id)) {
 				// Ensure the local widget state is aligned with what was returned by the server.
 				isInState = true
@@ -172,9 +184,9 @@ func setDashboardValuesFromRead(dashboard *swoClient.ReadDashboardResult, state 
 		}
 
 		// If the terraform state doesn't have a widget returned from a Read we need to add it to align the
-		// state with the server. This can happen if a dashboard is modified outside of terraform (e.g. in the UI).
+		// state with the server. This can happen if a dashboard is modified outside terraform (e.g., in the UI).
 		if !isInState {
-			state.Widgets = append(state.Widgets, dashboardWidgetModel{
+			stateWidgets = append(stateWidgets, dashboardWidgetModel{
 				Id:         types.StringValue(w.Id),
 				Type:       types.StringValue(w.Type),
 				X:          types.Int64Value(int64(layout.X)),
@@ -186,6 +198,8 @@ func setDashboardValuesFromRead(dashboard *swoClient.ReadDashboardResult, state 
 		}
 	}
 
+	updatedWidgets, _ := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: WidgetAttributeTypes()}, stateWidgets)
+	state.Widgets = updatedWidgets
 	return nil
 }
 
@@ -196,7 +210,7 @@ func (r *dashboardResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	widgets, layouts, err := widgetsFromPlan(tfPlan)
+	widgets, layouts, err := widgetsFromPlan(ctx, tfPlan)
 	if err != nil {
 		resp.Diagnostics.AddError("swo provider error",
 			fmt.Sprintf("convert plan to API error: %s, name: %s", err, tfPlan.Name))
@@ -221,7 +235,7 @@ func (r *dashboardResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	err = setDashboardValuesFromCreate(dashboard, &tfPlan)
+	err = setDashboardValuesFromCreate(ctx, dashboard, &tfPlan)
 	if err != nil {
 		resp.Diagnostics.AddError("swo provider error",
 			fmt.Sprintf("set dashboard computed values error: %s, id: %s", err, dashboard.Id))
@@ -250,7 +264,7 @@ func (r *dashboardResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	err = setDashboardValuesFromRead(dashboard, &tfState)
+	err = setDashboardValuesFromRead(ctx, dashboard, &tfState)
 	if err != nil {
 		resp.Diagnostics.AddError("swo provider error",
 			fmt.Sprintf("error updating local state for dashboard: %s, id: %s", err, tfState.Id))
@@ -268,10 +282,10 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	// Computed values like Id need to be read from terraform state.
+	// Computed value Id needs to be read from terraform state.
 	id := state.Id.ValueString()
 
-	widgets, layouts, err := widgetsFromPlan(plan)
+	widgets, layouts, err := widgetsFromPlan(ctx, plan)
 	if err != nil {
 		resp.Diagnostics.AddError("swo provider error",
 			fmt.Sprintf("error converting plan to api: %s, name: %s", err, plan.Name))
@@ -296,7 +310,7 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	// The create and update response objects are identical so we convert so we don't have to have 2 separate
+	// The create and update response objects are identical so we convert, so we don't have to have 2 separate
 	// methods for 'setDashboardValuesFromCreate()'.
 	d, err := convertObject[swoClient.CreateDashboardResult](dashboard)
 	if err != nil {
@@ -305,7 +319,7 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	err = setDashboardValuesFromCreate(d, &plan)
+	err = setDashboardValuesFromCreate(ctx, d, &plan)
 	if err != nil {
 		resp.Diagnostics.AddError("swo provider error",
 			fmt.Sprintf("error setting computed values for dashboard: %s, id: %s", err, state.Id))

--- a/internal/provider/dashboard_resource_test.go
+++ b/internal/provider/dashboard_resource_test.go
@@ -20,9 +20,21 @@ func TestAccDashboardResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("swo_dashboard.test", "id"),
 					resource.TestCheckResourceAttr("swo_dashboard.test", "name", "test-acc swo-terraform-provider [CREATE_TEST]"),
+					resource.TestCheckResourceAttr("swo_dashboard.test", "is_private", "true"),
+
 					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.#", "2"),
+
 					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.0.type", "TimeSeries"),
+					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.0.x", "4"),
+					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.0.y", "0"),
+					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.0.width", "4"),
+					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.0.height", "2"),
+
+					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.1.type", "Kpi"),
+					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.1.x", "0"),
+					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.1.y", "0"),
 					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.1.width", "4"),
+					resource.TestCheckResourceAttr("swo_dashboard.test", "widgets.1.height", "2"),
 				),
 			},
 			// ImportState testing

--- a/internal/provider/dashboard_schema.go
+++ b/internal/provider/dashboard_schema.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -13,11 +14,11 @@ import (
 
 // The main Dashboard Resource model that is derived from the schema.
 type dashboardResourceModel struct {
-	Id         types.String           `tfsdk:"id"`
-	Name       types.String           `tfsdk:"name"`
-	IsPrivate  types.Bool             `tfsdk:"is_private"`
-	CategoryId types.String           `tfsdk:"category_id"`
-	Widgets    []dashboardWidgetModel `tfsdk:"widgets"`
+	Id         types.String `tfsdk:"id"`
+	Name       types.String `tfsdk:"name"`
+	IsPrivate  types.Bool   `tfsdk:"is_private"`
+	CategoryId types.String `tfsdk:"category_id"`
+	Widgets    types.Set    `tfsdk:"widgets"`
 }
 
 type dashboardWidgetModel struct {
@@ -28,6 +29,18 @@ type dashboardWidgetModel struct {
 	Width      types.Int64  `tfsdk:"width"`
 	Height     types.Int64  `tfsdk:"height"`
 	Properties types.String `tfsdk:"properties"`
+}
+
+func WidgetAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":         types.StringType,
+		"type":       types.StringType,
+		"x":          types.Int64Type,
+		"y":          types.Int64Type,
+		"width":      types.Int64Type,
+		"height":     types.Int64Type,
+		"properties": types.StringType,
+	}
 }
 
 func (r *dashboardResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/provider/log_filter_resource.go
+++ b/internal/provider/log_filter_resource.go
@@ -97,14 +97,6 @@ func (r *logFilterResource) Read(ctx context.Context, req resource.ReadRequest, 
 	tfState.Description = types.StringValue(*logFilter.Description)
 	tfState.TokenSignature = types.StringValue(*logFilter.TokenSignature)
 
-	var lfe []logFilterExpression
-	for _, p := range logFilter.Expressions {
-		lfe = append(lfe, logFilterExpression{
-			Kind:       types.StringValue(string(p.Kind)),
-			Expression: types.StringValue(p.Expression),
-		})
-	}
-
 	var diags diag.Diagnostics
 	var elements []attr.Value
 	var attributeTypes = ExpressionAttributeTypes()

--- a/internal/provider/log_filter_resource.go
+++ b/internal/provider/log_filter_resource.go
@@ -107,22 +107,20 @@ func (r *logFilterResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	var diags diag.Diagnostics
 	var elements []attr.Value
-	var attributeTypes = map[string]attr.Type{
-		"kind":       types.StringType,
-		"expression": types.StringType,
-	}
+	var attributeTypes = ExpressionAttributeTypes()
 	for _, p := range logFilter.Expressions {
-		objectValue, objectDiags := types.ObjectValue(
+		objectValue, objectDiags := types.ObjectValueFrom(
+			ctx,
 			attributeTypes,
-			map[string]attr.Value{
-				"kind":       types.StringValue(string(p.Kind)),
-				"expression": types.StringValue(p.Expression),
+			logFilterExpression{
+				Kind:       types.StringValue(string(p.Kind)),
+				Expression: types.StringValue(p.Expression),
 			},
 		)
 		elements = append(elements, objectValue)
 		diags = append(diags, objectDiags...)
 	}
-	expressions, setDiags := types.ListValue(types.ObjectType{AttrTypes: attributeTypes}, elements)
+	expressions, setDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: attributeTypes}, elements)
 	diags = append(diags, setDiags...)
 	tfState.Expressions = expressions
 

--- a/internal/provider/log_filter_resource.go
+++ b/internal/provider/log_filter_resource.go
@@ -49,8 +49,8 @@ func (r *logFilterResource) Create(ctx context.Context, req resource.CreateReque
 		TokenSignature: tfPlan.TokenSignature.ValueStringPointer(),
 		Expressions: convertArray(tfPlan.Expressions, func(e logFilterExpression) swoClient.CreateExclusionFilterExpressionInput {
 			return swoClient.CreateExclusionFilterExpressionInput{
-				Kind:       swoClient.ExclusionFilterExpressionKind(e.Kind),
-				Expression: e.Expression,
+				Kind:       swoClient.ExclusionFilterExpressionKind(e.Kind.ValueString()),
+				Expression: e.Expression.ValueString(),
 			}
 		}),
 	}
@@ -95,8 +95,8 @@ func (r *logFilterResource) Read(ctx context.Context, req resource.ReadRequest, 
 	var lfe []logFilterExpression
 	for _, p := range logFilter.Expressions {
 		lfe = append(lfe, logFilterExpression{
-			Kind:       swoClient.ExclusionFilterExpressionKind(p.Kind),
-			Expression: p.Expression,
+			Kind:       types.StringValue(string(p.Kind)),
+			Expression: types.StringValue(p.Expression),
 		})
 	}
 	tfState.Expressions = lfe
@@ -120,8 +120,8 @@ func (r *logFilterResource) Update(ctx context.Context, req resource.UpdateReque
 		Description: tfPlan.Description.ValueString(),
 		Expressions: convertArray(tfPlan.Expressions, func(e logFilterExpression) swoClient.UpdateExclusionFilterExpressionInput {
 			return swoClient.UpdateExclusionFilterExpressionInput{
-				Kind:       swoClient.ExclusionFilterExpressionKind(e.Kind),
-				Expression: e.Expression,
+				Kind:       swoClient.ExclusionFilterExpressionKind(e.Kind.ValueString()),
+				Expression: e.Expression.ValueString(),
 			}
 		}),
 	})

--- a/internal/provider/log_filter_resource_test.go
+++ b/internal/provider/log_filter_resource_test.go
@@ -21,6 +21,8 @@ func TestAccLogFilterResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_logfilter.test", "name", "test-acc test one"),
 					resource.TestCheckResourceAttr("swo_logfilter.test", "description", "test description"),
 					resource.TestCheckResourceAttr("swo_logfilter.test", "token_signature", "U2aWJEYwSj-pvYegZdH1ozoq3kwapdngO1qDU3a8WXY"),
+					resource.TestCheckResourceAttr("swo_logfilter.test", "expressions.0.kind", "STRING"),
+					resource.TestCheckResourceAttr("swo_logfilter.test", "expressions.0.expression", "test expression"),
 				),
 			},
 			// ImportState testing

--- a/internal/provider/log_filter_schema.go
+++ b/internal/provider/log_filter_schema.go
@@ -14,11 +14,11 @@ import (
 
 // logFilterResourceModel is the main resource structure
 type logFilterResourceModel struct {
-	Id             types.String          `tfsdk:"id"`
-	Name           types.String          `tfsdk:"name"`
-	Description    types.String          `tfsdk:"description"`
-	TokenSignature types.String          `tfsdk:"token_signature"`
-	Expressions    []logFilterExpression `tfsdk:"expressions"`
+	Id             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Description    types.String `tfsdk:"description"`
+	TokenSignature types.String `tfsdk:"token_signature"`
+	Expressions    types.List   `tfsdk:"expressions"`
 }
 
 // LogFilterResourceOptions represents the options field in the main resource

--- a/internal/provider/log_filter_schema.go
+++ b/internal/provider/log_filter_schema.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 
 	swoClient "github.com/solarwinds/swo-client-go/pkg/client"
 	"github.com/solarwinds/terraform-provider-swo/internal/validators"
@@ -25,6 +26,13 @@ type logFilterResourceModel struct {
 type logFilterExpression struct {
 	Kind       types.String `tfsdk:"kind"`
 	Expression types.String `tfsdk:"expression"`
+}
+
+func ExpressionAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"kind":       types.StringType,
+		"expression": types.StringType,
+	}
 }
 
 func (r *logFilterResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/provider/log_filter_schema.go
+++ b/internal/provider/log_filter_schema.go
@@ -23,8 +23,8 @@ type logFilterResourceModel struct {
 
 // LogFilterResourceOptions represents the options field in the main resource
 type logFilterExpression struct {
-	Kind       swoClient.ExclusionFilterExpressionKind `tfsdk:"kind"`
-	Expression string                                  `tfsdk:"expression"`
+	Kind       types.String `tfsdk:"kind"`
+	Expression types.String `tfsdk:"expression"`
 }
 
 func (r *logFilterResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	dataSources           []func() datasource.DataSource
-	ErrNonMatchingEntites = errors.New("updated entity properties don't match")
+	dataSources            []func() datasource.DataSource
+	ErrNonMatchingEntities = errors.New("updated entity properties don't match")
 )
 
 var resources = []func() resource.Resource{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -23,6 +23,7 @@ import (
 var (
 	dataSources            []func() datasource.DataSource
 	ErrNonMatchingEntities = errors.New("updated entity properties don't match")
+	ErrMarshal             = errors.New("error during marshalling")
 )
 
 var resources = []func() resource.Resource{

--- a/internal/provider/uri_resource.go
+++ b/internal/provider/uri_resource.go
@@ -51,15 +51,27 @@ func (r *uriResource) Create(ctx context.Context, req resource.CreateRequest, re
 	var planOptions uriResourceOptions
 	d := tfPlan.Options.As(ctx, &planOptions, basetypes.ObjectAsOptions{})
 	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	var tcpOptions uriResourceTcpOptions
 	d = tfPlan.TcpOptions.As(ctx, &tcpOptions, basetypes.ObjectAsOptions{})
 	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	var testDefinitions uriResourceTestDefinitions
 	d = tfPlan.TestDefinitions.As(ctx, &testDefinitions, basetypes.ObjectAsOptions{})
 	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	var planPlatformOptions uriResourcePlatformOptions
 	d = testDefinitions.PlatformOptions.As(ctx, &planPlatformOptions, basetypes.ObjectAsOptions{})
 	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	var locationOptions []uriResourceProbeLocation
 	d = testDefinitions.LocationOptions.ElementsAs(ctx, &locationOptions, false)
 	resp.Diagnostics.Append(d...)
@@ -244,15 +256,35 @@ func (r *uriResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	var planOptions uriResourceOptions
-	tfPlan.Options.As(ctx, &planOptions, basetypes.ObjectAsOptions{})
+	d := tfPlan.Options.As(ctx, &planOptions, basetypes.ObjectAsOptions{})
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	var tcpOptions uriResourceTcpOptions
-	tfPlan.TcpOptions.As(ctx, &tcpOptions, basetypes.ObjectAsOptions{})
+	d = tfPlan.TcpOptions.As(ctx, &tcpOptions, basetypes.ObjectAsOptions{})
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	var testDefinitions uriResourceTestDefinitions
-	tfPlan.TestDefinitions.As(ctx, &testDefinitions, basetypes.ObjectAsOptions{})
+	d = tfPlan.TestDefinitions.As(ctx, &testDefinitions, basetypes.ObjectAsOptions{})
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	var planPlatformOptions uriResourcePlatformOptions
-	testDefinitions.PlatformOptions.As(ctx, &planPlatformOptions, basetypes.ObjectAsOptions{})
+	d = testDefinitions.PlatformOptions.As(ctx, &planPlatformOptions, basetypes.ObjectAsOptions{})
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	var locationOptions []uriResourceProbeLocation
-	testDefinitions.LocationOptions.ElementsAs(ctx, &locationOptions, false)
+	d = testDefinitions.LocationOptions.ElementsAs(ctx, &locationOptions, false)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Create our input request.
 	updateInput := swoClient.UpdateUriInput{
@@ -285,7 +317,11 @@ func (r *uriResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	var platforms []string
-	planPlatformOptions.Platforms.ElementsAs(ctx, &platforms, false)
+	d = planPlatformOptions.Platforms.ElementsAs(ctx, &platforms, false)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	bUriToMatch, err := json.Marshal(map[string]interface{}{
 		"id":   updateInput.Id,

--- a/internal/provider/uri_resource.go
+++ b/internal/provider/uri_resource.go
@@ -121,16 +121,14 @@ func (r *uriResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	tfState.Name = types.StringPointerValue(uri.Name)
 
 	// Options
-	optionsElementTypes := UriResourceOptionsAttributeTypes()
 	optionsElement := uriResourceOptions{
 		IsPingEnabled: types.BoolValue(uri.Options.IsPingEnabled),
 		IsTcpEnabled:  types.BoolValue(uri.Options.IsTcpEnabled),
 	}
-	tfOptions, _ := types.ObjectValueFrom(ctx, optionsElementTypes, optionsElement)
+	tfOptions, _ := types.ObjectValueFrom(ctx, UriResourceOptionsAttributeTypes(), optionsElement)
 	tfState.Options = tfOptions
 
 	// TcpOptions
-	tcpElementTypes := UriTcpOptionsAttributeTypes()
 	if uri.TcpOptions != nil {
 		tcpOptions := uri.TcpOptions
 		tcpElement := uriResourceTcpOptions{
@@ -145,11 +143,10 @@ func (r *uriResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 			tcpElement.StringToSend = types.StringValue(*tcpOptions.StringToSend)
 		}
 
-		tfTcpOptions, _ := types.ObjectValueFrom(ctx, tcpElementTypes, tcpElement)
+		tfTcpOptions, _ := types.ObjectValueFrom(ctx, UriTcpOptionsAttributeTypes(), tcpElement)
 		tfState.TcpOptions = tfTcpOptions
 	} else {
-		tfTcpOptions := types.ObjectNull(tcpElementTypes)
-		tfState.TcpOptions = tfTcpOptions
+		tfState.TcpOptions = types.ObjectNull(UriTcpOptionsAttributeTypes())
 	}
 
 	// TestDefinitions
@@ -162,7 +159,7 @@ func (r *uriResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		TestFromLocation:      types.StringNull(),
 		LocationOptions:       types.SetUnknown(types.ObjectType{AttrTypes: locationOptsElementTypes}),
 		TestIntervalInSeconds: types.Int64Null(),
-		PlatformOptions:       types.ObjectNull(platformElementTypes),
+		PlatformOptions:       types.ObjectNull(UriPlatformOptionsAttributeTypes()),
 	}
 	if testDefs.TestFromLocation != nil {
 		testDefsElements.TestFromLocation = types.StringValue(string(*testDefs.TestFromLocation))

--- a/internal/provider/uri_resource.go
+++ b/internal/provider/uri_resource.go
@@ -390,7 +390,7 @@ func (r *uriResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 		// Updated entity properties don't match, retry
 		if !match {
-			return nil, ErrNonMatchingEntites
+			return nil, ErrNonMatchingEntities
 		}
 
 		return uri, nil

--- a/internal/provider/uri_resource.go
+++ b/internal/provider/uri_resource.go
@@ -131,8 +131,8 @@ func (r *uriResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		IsPingEnabled: types.BoolValue(uri.Options.IsPingEnabled),
 		IsTcpEnabled:  types.BoolValue(uri.Options.IsTcpEnabled),
 	}
-	tfOptions, od := types.ObjectValueFrom(ctx, UriResourceOptionsAttributeTypes(), optionsElement)
-	resp.Diagnostics.Append(od...)
+	tfOptions, diags := types.ObjectValueFrom(ctx, UriResourceOptionsAttributeTypes(), optionsElement)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/uri_resource_test.go
+++ b/internal/provider/uri_resource_test.go
@@ -20,8 +20,22 @@ func TestAccUriResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("swo_uri.test", "id"),
 					resource.TestCheckResourceAttr("swo_uri.test", "name", "test-acc test one [CREATE_TEST]"),
 					resource.TestCheckResourceAttr("swo_uri.test", "host", "example.com"),
+
 					resource.TestCheckResourceAttr("swo_uri.test", "options.is_ping_enabled", "false"),
 					resource.TestCheckResourceAttr("swo_uri.test", "options.is_tcp_enabled", "true"),
+
+					resource.TestCheckResourceAttr("swo_uri.test", "tcp_options.port", "80"),
+					resource.TestCheckResourceAttr("swo_uri.test", "tcp_options.string_to_expect", "string to expect"),
+					resource.TestCheckResourceAttr("swo_uri.test", "tcp_options.string_to_send", "string to send"),
+
+					resource.TestCheckResourceAttr("swo_uri.test", "test_definitions.test_from_location", "REGION"),
+					resource.TestCheckResourceAttr("swo_uri.test", "test_definitions.test_interval_in_seconds", "300"),
+					resource.TestCheckResourceAttr("swo_uri.test", "test_definitions.platform_options.test_from_all", "false"),
+					resource.TestCheckResourceAttr("swo_uri.test", "test_definitions.platform_options.platforms.#", "1"),
+					resource.TestCheckResourceAttr("swo_uri.test", "test_definitions.platform_options.platforms.0", "AWS"),
+					resource.TestCheckResourceAttr("swo_uri.test", "test_definitions.location_options.#", "1"),
+					resource.TestCheckResourceAttr("swo_uri.test", "test_definitions.location_options.0.type", "REGION"),
+					resource.TestCheckResourceAttr("swo_uri.test", "test_definitions.location_options.0.value", "NA"),
 				),
 			},
 			// ImportState testing
@@ -42,6 +56,8 @@ func TestAccUriResource(t *testing.T) {
 	})
 }
 
+// Only supported regions (location_options.value) in Dev and Stage are NA
+// Production supports the following: NA, AS, SA, OC
 func testAccUriResourceConfig(name string) string {
 	return providerConfig() + fmt.Sprintf(`
 	resource "swo_uri" "test" {
@@ -66,18 +82,6 @@ func testAccUriResourceConfig(name string) string {
 				{
 					type  = "REGION"
 					value = "NA"
-				},
-				{
-					type  = "REGION"
-					value = "AS"
-				},
-				{
-					type  = "REGION"
-					value = "SA"
-				},
-				{
-					type  = "REGION"
-					value = "OC"
 				}
 			]
 	

--- a/internal/provider/uri_resource_test.go
+++ b/internal/provider/uri_resource_test.go
@@ -66,18 +66,6 @@ func testAccUriResourceConfig(name string) string {
 				{
 					type  = "REGION"
 					value = "NA"
-				},
-				{
-					type  = "REGION"
-					value = "AS"
-				},
-				{
-					type  = "REGION"
-					value = "SA"
-				},
-				{
-					type  = "REGION"
-					value = "OC"
 				}
 			]
 	

--- a/internal/provider/uri_resource_test.go
+++ b/internal/provider/uri_resource_test.go
@@ -66,6 +66,18 @@ func testAccUriResourceConfig(name string) string {
 				{
 					type  = "REGION"
 					value = "NA"
+				},
+				{
+					type  = "REGION"
+					value = "AS"
+				},
+				{
+					type  = "REGION"
+					value = "SA"
+				},
+				{
+					type  = "REGION"
+					value = "OC"
 				}
 			]
 	

--- a/internal/provider/uri_schema.go
+++ b/internal/provider/uri_schema.go
@@ -38,7 +38,7 @@ type uriResourceTcpOptions struct {
 // uriResourceTestDefinitions represents the test_definitions field in the main resource
 type uriResourceTestDefinitions struct {
 	TestFromLocation      types.String                `tfsdk:"test_from_location"`
-	LocationOptions       []uriResourceProbeLocation  `tfsdk:"location_options"`
+	LocationOptions       types.Set                   `tfsdk:"location_options"`
 	TestIntervalInSeconds types.Int64                 `tfsdk:"test_interval_in_seconds"`
 	PlatformOptions       *uriResourcePlatformOptions `tfsdk:"platform_options"`
 }

--- a/internal/provider/uri_schema.go
+++ b/internal/provider/uri_schema.go
@@ -52,7 +52,7 @@ type uriResourceProbeLocation struct {
 // uriResourcePlatformOptions represents platform_options field in test_definitions
 type uriResourcePlatformOptions struct {
 	TestFromAll types.Bool `tfsdk:"test_from_all"`
-	Platforms   []string   `tfsdk:"platforms"`
+	Platforms   types.Set  `tfsdk:"platforms"`
 }
 
 func (r *uriResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/provider/uri_schema.go
+++ b/internal/provider/uri_schema.go
@@ -18,7 +18,7 @@ type uriResourceModel struct {
 	Name            types.String                `tfsdk:"name"`
 	Host            types.String                `tfsdk:"host"`
 	Options         types.Object                `tfsdk:"options"`
-	TcpOptions      *uriResourceTcpOptions      `tfsdk:"tcp_options"`
+	TcpOptions      types.Object                `tfsdk:"tcp_options"`
 	TestDefinitions *uriResourceTestDefinitions `tfsdk:"test_definitions"`
 }
 

--- a/internal/provider/uri_schema.go
+++ b/internal/provider/uri_schema.go
@@ -18,12 +18,11 @@ type uriResourceModel struct {
 	Id              types.String `tfsdk:"id"`
 	Name            types.String `tfsdk:"name"`
 	Host            types.String `tfsdk:"host"`
-	Options         types.Object `tfsdk:"options"`
-	TcpOptions      types.Object `tfsdk:"tcp_options"`
-	TestDefinitions types.Object `tfsdk:"test_definitions"`
+	Options         types.Object `tfsdk:"options"`          //uriResourceOptions
+	TcpOptions      types.Object `tfsdk:"tcp_options"`      //uriResourceTcpOptions
+	TestDefinitions types.Object `tfsdk:"test_definitions"` //uriResourceTestDefinitions
 }
 
-// uriResourceOptions represents the options field in the main resource
 type uriResourceOptions struct {
 	IsPingEnabled types.Bool `tfsdk:"is_ping_enabled"`
 	IsTcpEnabled  types.Bool `tfsdk:"is_tcp_enabled"`
@@ -36,7 +35,6 @@ func UriResourceOptionsAttributeTypes() map[string]attr.Type {
 	}
 }
 
-// uriResourceTcpOptions represents the tcp_options field in the main resource
 type uriResourceTcpOptions struct {
 	Port           types.Int64  `tfsdk:"port"`
 	StringToExpect types.String `tfsdk:"string_to_expect"`
@@ -51,12 +49,11 @@ func UriTcpOptionsAttributeTypes() map[string]attr.Type {
 	}
 }
 
-// uriResourceTestDefinitions represents the test_definitions field in the main resource
 type uriResourceTestDefinitions struct {
 	TestFromLocation      types.String `tfsdk:"test_from_location"`
-	LocationOptions       types.Set    `tfsdk:"location_options"`
+	LocationOptions       types.Set    `tfsdk:"location_options"` // uriResourceProbeLocation
 	TestIntervalInSeconds types.Int64  `tfsdk:"test_interval_in_seconds"`
-	PlatformOptions       types.Object `tfsdk:"platform_options"`
+	PlatformOptions       types.Object `tfsdk:"platform_options"` //uriResourcePlatformOptions
 }
 
 func UriTestDefAttributeTypes() map[string]attr.Type {
@@ -68,7 +65,6 @@ func UriTestDefAttributeTypes() map[string]attr.Type {
 	}
 }
 
-// uriResourceProbeLocation represents location_options field in test_definitions
 type uriResourceProbeLocation struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
@@ -81,7 +77,6 @@ func UriProbeLocationAttributeTypes() map[string]attr.Type {
 	}
 }
 
-// uriResourcePlatformOptions represents platform_options field in test_definitions
 type uriResourcePlatformOptions struct {
 	TestFromAll types.Bool `tfsdk:"test_from_all"`
 	Platforms   types.Set  `tfsdk:"platforms"`

--- a/internal/provider/uri_schema.go
+++ b/internal/provider/uri_schema.go
@@ -17,7 +17,7 @@ type uriResourceModel struct {
 	Id              types.String                `tfsdk:"id"`
 	Name            types.String                `tfsdk:"name"`
 	Host            types.String                `tfsdk:"host"`
-	Options         *uriResourceOptions         `tfsdk:"options"`
+	Options         types.Object                `tfsdk:"options"`
 	TcpOptions      *uriResourceTcpOptions      `tfsdk:"tcp_options"`
 	TestDefinitions *uriResourceTestDefinitions `tfsdk:"test_definitions"`
 }

--- a/internal/provider/uri_schema.go
+++ b/internal/provider/uri_schema.go
@@ -14,12 +14,12 @@ import (
 
 // uriResourceModel is the main resource structure
 type uriResourceModel struct {
-	Id              types.String                `tfsdk:"id"`
-	Name            types.String                `tfsdk:"name"`
-	Host            types.String                `tfsdk:"host"`
-	Options         types.Object                `tfsdk:"options"`
-	TcpOptions      types.Object                `tfsdk:"tcp_options"`
-	TestDefinitions *uriResourceTestDefinitions `tfsdk:"test_definitions"`
+	Id              types.String `tfsdk:"id"`
+	Name            types.String `tfsdk:"name"`
+	Host            types.String `tfsdk:"host"`
+	Options         types.Object `tfsdk:"options"`
+	TcpOptions      types.Object `tfsdk:"tcp_options"`
+	TestDefinitions types.Object `tfsdk:"test_definitions"`
 }
 
 // uriResourceOptions represents the options field in the main resource

--- a/internal/provider/uri_schema.go
+++ b/internal/provider/uri_schema.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -28,11 +29,26 @@ type uriResourceOptions struct {
 	IsTcpEnabled  types.Bool `tfsdk:"is_tcp_enabled"`
 }
 
+func UriResourceOptionsAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"is_ping_enabled": types.BoolType,
+		"is_tcp_enabled":  types.BoolType,
+	}
+}
+
 // uriResourceTcpOptions represents the tcp_options field in the main resource
 type uriResourceTcpOptions struct {
 	Port           types.Int64  `tfsdk:"port"`
 	StringToExpect types.String `tfsdk:"string_to_expect"`
 	StringToSend   types.String `tfsdk:"string_to_send"`
+}
+
+func UriTcpOptionsAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"port":             types.Int64Type,
+		"string_to_expect": types.StringType,
+		"string_to_send":   types.StringType,
+	}
 }
 
 // uriResourceTestDefinitions represents the test_definitions field in the main resource
@@ -43,16 +59,39 @@ type uriResourceTestDefinitions struct {
 	PlatformOptions       types.Object `tfsdk:"platform_options"`
 }
 
+func UriTestDefAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"test_from_location":       types.StringType,
+		"location_options":         types.SetType{ElemType: types.ObjectType{AttrTypes: UriProbeLocationAttributeTypes()}},
+		"test_interval_in_seconds": types.Int64Type,
+		"platform_options":         types.ObjectType{AttrTypes: UriPlatformOptionsAttributeTypes()},
+	}
+}
+
 // uriResourceProbeLocation represents location_options field in test_definitions
 type uriResourceProbeLocation struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
 }
 
+func UriProbeLocationAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"type":  types.StringType,
+		"value": types.StringType,
+	}
+}
+
 // uriResourcePlatformOptions represents platform_options field in test_definitions
 type uriResourcePlatformOptions struct {
 	TestFromAll types.Bool `tfsdk:"test_from_all"`
 	Platforms   types.Set  `tfsdk:"platforms"`
+}
+
+func UriPlatformOptionsAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"test_from_all": types.BoolType,
+		"platforms":     types.SetType{ElemType: types.StringType},
+	}
 }
 
 func (r *uriResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/provider/uri_schema.go
+++ b/internal/provider/uri_schema.go
@@ -37,10 +37,10 @@ type uriResourceTcpOptions struct {
 
 // uriResourceTestDefinitions represents the test_definitions field in the main resource
 type uriResourceTestDefinitions struct {
-	TestFromLocation      types.String                `tfsdk:"test_from_location"`
-	LocationOptions       types.Set                   `tfsdk:"location_options"`
-	TestIntervalInSeconds types.Int64                 `tfsdk:"test_interval_in_seconds"`
-	PlatformOptions       *uriResourcePlatformOptions `tfsdk:"platform_options"`
+	TestFromLocation      types.String `tfsdk:"test_from_location"`
+	LocationOptions       types.Set    `tfsdk:"location_options"`
+	TestIntervalInSeconds types.Int64  `tfsdk:"test_interval_in_seconds"`
+	PlatformOptions       types.Object `tfsdk:"platform_options"`
 }
 
 // uriResourceProbeLocation represents location_options field in test_definitions

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -245,7 +245,11 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 				platforms := convertArray(availability.PlatformOptions.Platforms, func(p string) types.String {
 					return types.StringValue(p)
 				})
-				platformValue, _ := types.SetValueFrom(ctx, types.StringType, platforms)
+				platformValue, d := types.SetValueFrom(ctx, types.StringType, platforms)
+				resp.Diagnostics.Append(d...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
 
 				platformOptionsValue := platformOptions{
 					TestFromAll: types.BoolValue(availability.PlatformOptions.TestFromAll),
@@ -273,7 +277,11 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 					locOpts = append(locOpts, objectValue)
 				}
 
-				tfLocationOptions, _ := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: ProbeLocationAttributeTypes()}, locOpts)
+				tfLocationOptions, d := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: ProbeLocationAttributeTypes()}, locOpts)
+				resp.Diagnostics.Append(d...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
 				tfStateAvailability.LocationOptions = tfLocationOptions
 			}
 
@@ -315,8 +323,11 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 				elements = append(elements, objectValue)
 				diags = append(diags, objectDiags...)
 			}
-			customHeaderValue, setDiags := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: customHeaderElementTypes}, elements)
-			diags = append(diags, setDiags...)
+			customHeaderValue, d := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: customHeaderElementTypes}, elements)
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 
 			var m availabilityMonitoring
 			tfStateMonitoring.Availability.As(ctx, &m, basetypes.ObjectAsOptions{})

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -308,6 +308,10 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 					Platforms:   platformValue,
 				}
 				tfPlatformOptions, d := types.ObjectValueFrom(ctx, PlatformOptionsAttributeTypes(), platformOptionsValue)
+				resp.Diagnostics.Append(d...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
 				tfStateAvailability.PlatformOptions = tfPlatformOptions
 			}
 
@@ -707,7 +711,7 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 
 		// Updated entity properties don't match, retry
 		if !match {
-			return nil, ErrNonMatchingEntites
+			return nil, ErrNonMatchingEntities
 		}
 
 		return website, nil

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -86,9 +86,17 @@ func (r *websiteResource) Create(ctx context.Context, req resource.CreateRequest
 		var tfCustomHeaders []customHeader
 		//monitoring.custom_headers is deprecated. Both custom_headers fields cannot be set at the same time.
 		if !tfAvailability.CustomHeaders.IsNull() {
-			tfAvailability.CustomHeaders.ElementsAs(ctx, &tfCustomHeaders, false)
+			d := tfAvailability.CustomHeaders.ElementsAs(ctx, &tfCustomHeaders, false)
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 		} else {
-			tfMonitoring.CustomHeaders.ElementsAs(ctx, &tfCustomHeaders, false)
+			d := tfMonitoring.CustomHeaders.ElementsAs(ctx, &tfCustomHeaders, false)
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 		}
 
 		var customHeaders []swoClient.CustomHeaderInput
@@ -102,9 +110,17 @@ func (r *websiteResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 
 		var tfLocationOptions []probeLocation
-		tfAvailability.LocationOptions.ElementsAs(ctx, &tfLocationOptions, false)
+		d := tfAvailability.LocationOptions.ElementsAs(ctx, &tfLocationOptions, false)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		var tfPlatformOpts platformOptions
-		tfAvailability.PlatformOptions.As(ctx, &tfPlatformOpts, basetypes.ObjectAsOptions{})
+		d = tfAvailability.PlatformOptions.As(ctx, &tfPlatformOpts, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		createInput.AvailabilityCheckSettings = &swoClient.AvailabilityCheckSettingsInput{
 			CheckForString:        checkForString,
@@ -466,9 +482,17 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 		var tfCustomHeaders []customHeader
 		//monitoring.custom_headers is deprecated. Both custom_headers fields cannot be set at the same time.
 		if !tfAvailability.CustomHeaders.IsNull() {
-			tfAvailability.CustomHeaders.ElementsAs(ctx, &tfCustomHeaders, false)
+			d := tfAvailability.CustomHeaders.ElementsAs(ctx, &tfCustomHeaders, false)
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 		} else {
-			tfMonitoring.CustomHeaders.ElementsAs(ctx, &tfCustomHeaders, false)
+			d := tfMonitoring.CustomHeaders.ElementsAs(ctx, &tfCustomHeaders, false)
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 		}
 
 		var customHeaders []swoClient.CustomHeaderInput
@@ -482,9 +506,17 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 		}
 
 		var tfLocationOptions []probeLocation
-		tfAvailability.LocationOptions.ElementsAs(ctx, &tfLocationOptions, false)
+		d := tfAvailability.LocationOptions.ElementsAs(ctx, &tfLocationOptions, false)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		var tfPlatformOpts platformOptions
-		tfAvailability.PlatformOptions.As(ctx, &tfPlatformOpts, basetypes.ObjectAsOptions{})
+		d = tfAvailability.PlatformOptions.As(ctx, &tfPlatformOpts, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		updateInput.AvailabilityCheckSettings = &swoClient.AvailabilityCheckSettingsInput{
 			CheckForString:        checkForString,
@@ -638,9 +670,17 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 		tfRum.Snippet = types.StringValue(*website.Monitoring.Rum.Snippet)
 
 		rumValue, d := types.ObjectValueFrom(ctx, RumMonitoringAttributeTypes(), tfRum)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		tfMonitoring.Rum = rumValue
 
 		monitoringValue, d := types.ObjectValueFrom(ctx, WebsiteMonitoringAttributeTypes(), tfMonitoring)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		tfPlan.Monitoring = monitoringValue
 	}
 

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -54,15 +54,28 @@ func (r *websiteResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	var tfMonitoring websiteMonitoring
-	tfPlan.Monitoring.As(ctx, &tfMonitoring, basetypes.ObjectAsOptions{})
+	d := tfPlan.Monitoring.As(ctx, &tfMonitoring, basetypes.ObjectAsOptions{})
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if !tfMonitoring.Availability.IsNull() {
 		var tfAvailability availabilityMonitoring
-		tfMonitoring.Availability.As(ctx, &tfAvailability, basetypes.ObjectAsOptions{})
+		d = tfMonitoring.Availability.As(ctx, &tfAvailability, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		var checkForString *swoClient.CheckForStringInput
 		if !tfAvailability.CheckForString.IsNull() {
 			var tfCheckForString checkForStringType
-			tfAvailability.CheckForString.As(ctx, &tfCheckForString, basetypes.ObjectAsOptions{})
+			d = tfAvailability.CheckForString.As(ctx, &tfCheckForString, basetypes.ObjectAsOptions{})
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 
 			checkForString = &swoClient.CheckForStringInput{
 				Operator: swoClient.CheckStringOperator(tfCheckForString.Operator.ValueString()),
@@ -73,7 +86,11 @@ func (r *websiteResource) Create(ctx context.Context, req resource.CreateRequest
 		var ssl *swoClient.SslMonitoringInput
 		if !tfAvailability.SSL.IsUnknown() {
 			var tfSslMonitoring sslMonitoring
-			tfAvailability.SSL.As(ctx, &tfSslMonitoring, basetypes.ObjectAsOptions{})
+			d = tfAvailability.SSL.As(ctx, &tfSslMonitoring, basetypes.ObjectAsOptions{})
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 			if tfSslMonitoring.Enabled.ValueBool() {
 				ssl = &swoClient.SslMonitoringInput{
 					Enabled:                        tfSslMonitoring.Enabled.ValueBoolPointer(),
@@ -148,7 +165,11 @@ func (r *websiteResource) Create(ctx context.Context, req resource.CreateRequest
 
 	if !tfMonitoring.Rum.IsNull() {
 		var tfRum rumMonitoring
-		tfMonitoring.Rum.As(ctx, &tfRum, basetypes.ObjectAsOptions{})
+		d = tfMonitoring.Rum.As(ctx, &tfRum, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		createInput.Rum = &swoClient.RumMonitoringInput{
 			ApdexTimeInSeconds: swoClient.Ptr(int(tfRum.ApdexTimeInSeconds.ValueInt64())),
@@ -179,7 +200,11 @@ func (r *websiteResource) Create(ctx context.Context, req resource.CreateRequest
 	// Only set the snippet field if the user has RUM enabled.
 	if !tfMonitoring.Rum.IsNull() {
 		var rum rumMonitoring
-		tfMonitoring.Rum.As(ctx, &rum, basetypes.ObjectAsOptions{})
+		d = tfMonitoring.Rum.As(ctx, &rum, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		rum.Snippet = types.StringValue(*website.Monitoring.Rum.Snippet)
 
@@ -373,7 +398,12 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 			}
 
 			var m availabilityMonitoring
-			tfStateMonitoring.Availability.As(ctx, &m, basetypes.ObjectAsOptions{})
+			d = tfStateMonitoring.Availability.As(ctx, &m, basetypes.ObjectAsOptions{})
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
 			if !m.CustomHeaders.IsNull() {
 				m.CustomHeaders = customHeaderValue
 				tfStateMonitoring.CustomHeaders = nullCustomHeader
@@ -450,16 +480,28 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	var tfMonitoring websiteMonitoring
-	tfPlan.Monitoring.As(ctx, &tfMonitoring, basetypes.ObjectAsOptions{})
+	d := tfPlan.Monitoring.As(ctx, &tfMonitoring, basetypes.ObjectAsOptions{})
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	if !tfMonitoring.Availability.IsNull() {
 		var tfAvailability availabilityMonitoring
-		tfMonitoring.Availability.As(ctx, &tfAvailability, basetypes.ObjectAsOptions{})
+		d = tfMonitoring.Availability.As(ctx, &tfAvailability, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		var checkForString *swoClient.CheckForStringInput
 		if !tfAvailability.CheckForString.IsNull() {
 			var tfCheckForString checkForStringType
-			tfAvailability.CheckForString.As(ctx, &tfCheckForString, basetypes.ObjectAsOptions{})
+			d = tfAvailability.CheckForString.As(ctx, &tfCheckForString, basetypes.ObjectAsOptions{})
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 
 			checkForString = &swoClient.CheckForStringInput{
 				Operator: swoClient.CheckStringOperator(tfCheckForString.Operator.ValueString()),
@@ -469,7 +511,12 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 		var ssl *swoClient.SslMonitoringInput
 		if !tfAvailability.SSL.IsUnknown() {
 			var tfSslMonitoring sslMonitoring
-			tfAvailability.SSL.As(ctx, &tfSslMonitoring, basetypes.ObjectAsOptions{})
+			d = tfAvailability.SSL.As(ctx, &tfSslMonitoring, basetypes.ObjectAsOptions{})
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
 			if tfSslMonitoring.Enabled.ValueBool() {
 				ssl = &swoClient.SslMonitoringInput{
 					Enabled:                        tfSslMonitoring.Enabled.ValueBoolPointer(),
@@ -544,7 +591,11 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	if !tfMonitoring.Rum.IsNull() {
 		var tfRum rumMonitoring
-		tfMonitoring.Rum.As(ctx, &tfRum, basetypes.ObjectAsOptions{})
+		d = tfMonitoring.Rum.As(ctx, &tfRum, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		updateInput.Rum = &swoClient.RumMonitoringInput{
 			ApdexTimeInSeconds: swoClient.Ptr(int(tfRum.ApdexTimeInSeconds.ValueInt64())),
@@ -637,7 +688,12 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 		// default values for ssl are returned if ssl is not set
 		if !tfMonitoring.Availability.IsNull() {
 			var tfAvailability availabilityMonitoring
-			tfMonitoring.Availability.As(ctx, &tfAvailability, basetypes.ObjectAsOptions{})
+			d = tfMonitoring.Availability.As(ctx, &tfAvailability, basetypes.ObjectAsOptions{})
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return nil, nil
+			}
+
 			if tfAvailability.SSL.IsNull() {
 				websiteToMatch.Monitoring.Availability.Ssl = website.Monitoring.Availability.Ssl
 			}
@@ -662,10 +718,17 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 			fmt.Sprintf("error updating website %s. err: %s", tfState.Id, err))
 		return
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	if !tfMonitoring.Rum.IsNull() && website.Monitoring.Options.IsRumActive {
 		var tfRum rumMonitoring
-		tfMonitoring.Rum.As(ctx, &tfRum, basetypes.ObjectAsOptions{})
+		d = tfMonitoring.Rum.As(ctx, &tfRum, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		tfRum.Snippet = types.StringValue(*website.Monitoring.Rum.Snippet)
 

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -559,7 +559,6 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 		}
 
 		// default values for availability are returned if availability is not set
-		//todo this may be incorrect
 		if monitoring.Availability.IsNull() {
 			websiteToMatch.Monitoring.Availability = website.Monitoring.Availability
 		}

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -718,9 +718,6 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 			fmt.Sprintf("error updating website %s. err: %s", tfState.Id, err))
 		return
 	}
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	if !tfMonitoring.Rum.IsNull() && website.Monitoring.Options.IsRumActive {
 		var tfRum rumMonitoring

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -84,7 +84,7 @@ func (r *websiteResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 
 		var ssl *swoClient.SslMonitoringInput
-		if !tfAvailability.SSL.IsUnknown() {
+		if !tfAvailability.SSL.IsNull() {
 			var tfSslMonitoring sslMonitoring
 			d = tfAvailability.SSL.As(ctx, &tfSslMonitoring, basetypes.ObjectAsOptions{})
 			resp.Diagnostics.Append(d...)
@@ -509,7 +509,7 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 			}
 		}
 		var ssl *swoClient.SslMonitoringInput
-		if !tfAvailability.SSL.IsUnknown() {
+		if !tfAvailability.SSL.IsNull() {
 			var tfSslMonitoring sslMonitoring
 			d = tfAvailability.SSL.As(ctx, &tfSslMonitoring, basetypes.ObjectAsOptions{})
 			resp.Diagnostics.Append(d...)

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -229,9 +229,6 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 				}
 				checkForString, _ := types.ObjectValueFrom(ctx, CheckForStringTypeAttributeTypes(), elements)
 				tfStateAvailability.CheckForString = checkForString
-			} else {
-				//todo remove
-				tfStateAvailability.CheckForString = types.ObjectNull(CheckForStringTypeAttributeTypes())
 			}
 
 			if availability.TestIntervalInSeconds != nil {
@@ -256,23 +253,18 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 				}
 				tfPlatformOptions, _ := types.ObjectValueFrom(ctx, PlatformOptionsAttributeTypes(), platformOptionsValue)
 				tfStateAvailability.PlatformOptions = tfPlatformOptions
-			} else {
-				//todo remove
-				platformOpts := types.ObjectNull(PlatformOptionsAttributeTypes())
-				tfStateAvailability.PlatformOptions = platformOpts
 			}
 
 			if availability.TestFromLocation != nil {
 				tfStateAvailability.TestFromLocation = types.StringValue(string(*availability.TestFromLocation))
 			}
 
-			locationAttributeTypes := ProbeLocationAttributeTypes()
 			var locOpts []attr.Value
 			if len(availability.LocationOptions) > 0 {
 				for _, p := range availability.LocationOptions {
 					objectValue, _ := types.ObjectValueFrom(
 						ctx,
-						locationAttributeTypes,
+						ProbeLocationAttributeTypes(),
 						probeLocation{
 							Type:  types.StringValue(string(p.Type)),
 							Value: types.StringValue(p.Value),
@@ -281,11 +273,8 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 					locOpts = append(locOpts, objectValue)
 				}
 
-				tfLocationOptions, _ := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: locationAttributeTypes}, locOpts)
+				tfLocationOptions, _ := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: ProbeLocationAttributeTypes()}, locOpts)
 				tfStateAvailability.LocationOptions = tfLocationOptions
-			} else {
-				//todo remove
-				tfStateAvailability.LocationOptions = types.SetNull(types.ObjectType{AttrTypes: locationAttributeTypes})
 			}
 
 			sslTypes := SslMonitoringAttributeTypes()
@@ -307,9 +296,6 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 			availabilityValue, _ := types.ObjectValueFrom(ctx, AvailabilityMonitoringAttributeTypes(), tfStateAvailability)
 			tfStateMonitoring.Availability = availabilityValue
-		} else {
-			//todo remove
-			tfStateMonitoring.Availability = types.ObjectNull(AvailabilityMonitoringAttributeTypes())
 		}
 
 		customHeaderElementTypes := CustomHeaderAttributeTypes()
@@ -374,9 +360,6 @@ func (r *websiteResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 		tfState2, _ := types.ObjectValueFrom(ctx, WebsiteMonitoringAttributeTypes(), tfStateMonitoring)
 		tfState.Monitoring = tfState2
-	} else {
-		//todo remove
-		tfState.Monitoring = types.ObjectNull(WebsiteMonitoringAttributeTypes())
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, tfState)...)
@@ -569,7 +552,7 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 		if !tfMonitoring.Availability.IsNull() {
 			var tfAvailability availabilityMonitoring
 			tfMonitoring.Availability.As(ctx, &tfAvailability, basetypes.ObjectAsOptions{})
-			if tfAvailability.SSL.IsUnknown() {
+			if tfAvailability.SSL.IsNull() {
 				websiteToMatch.Monitoring.Availability.Ssl = website.Monitoring.Availability.Ssl
 			}
 		}

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -693,9 +693,8 @@ func (r *websiteResource) Update(ctx context.Context, req resource.UpdateRequest
 		if !tfMonitoring.Availability.IsNull() {
 			var tfAvailability availabilityMonitoring
 			d = tfMonitoring.Availability.As(ctx, &tfAvailability, basetypes.ObjectAsOptions{})
-			resp.Diagnostics.Append(d...)
-			if resp.Diagnostics.HasError() {
-				return nil, nil
+			if d.HasError() {
+				return nil, ErrMarshal
 			}
 
 			if tfAvailability.SSL.IsNull() {

--- a/internal/provider/website_resource_test.go
+++ b/internal/provider/website_resource_test.go
@@ -26,9 +26,9 @@ func TestAccWebsiteResource(t *testing.T) {
 			),
 			createTestStep(
 				testAccWebsiteResourceConfig,
-				"test-acc create without [CREATE_TEST]",
+				"test-acc create without options [CREATE_TEST]",
 				"https://solarwinds.com",
-				websiteMonitoringConfigWithoutAvailabilityOptionals,
+				websiteMonitoringConfigWithoutAvailabilityOptions,
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.0", "HTTP"),
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.1", "HTTPS"),
 			),
@@ -59,15 +59,15 @@ func TestAccWebsiteResource(t *testing.T) {
 			),
 			createTestStep(
 				testAccWebsiteResourceConfig,
-				"test-acc test update without [UPDATE_TEST]",
+				"test-acc test update without options [UPDATE_TEST]",
 				"https://solarwinds.com",
-				websiteMonitoringConfigWithoutAvailabilityOptionals,
+				websiteMonitoringConfigWithoutAvailabilityOptions,
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.0", "HTTP"),
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.1", "HTTPS"),
 			),
 			createTestStep(
 				testAccWebsiteResourceConfig,
-				"test-acc test update without [UPDATE_TEST]",
+				"test-acc test update without availability [UPDATE_TEST]",
 				"https://solarwinds.com",
 				websiteMonitoringConfigWithoutAvailability,
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.rum.apdex_time_in_seconds", "4"),
@@ -79,9 +79,9 @@ func TestAccWebsiteResource(t *testing.T) {
 }
 
 var (
-	websiteMonitoringConfig                             = monitoringConfig(availabilityConfig(true, true), "null", true)
-	websiteMonitoringConfigWithoutAvailability          = monitoringConfig("null", rumConfig(), false)
-	websiteMonitoringConfigWithoutAvailabilityOptionals = monitoringConfig(availabilityConfig(false, false), rumConfig(), true)
+	websiteMonitoringConfig                           = monitoringConfig(availabilityConfig(true, true), "null", true)
+	websiteMonitoringConfigWithoutAvailability        = monitoringConfig("null", rumConfig(), false)
+	websiteMonitoringConfigWithoutAvailabilityOptions = monitoringConfig(availabilityConfig(false, false), rumConfig(), true)
 )
 
 func createTestStep(configFunc func(string, string, string) string, name, url string, monitoring string, additionalChecks ...resource.TestCheckFunc) resource.TestStep {

--- a/internal/provider/website_resource_test.go
+++ b/internal/provider/website_resource_test.go
@@ -16,7 +16,7 @@ func TestAccWebsiteResource(t *testing.T) {
 			// Create and Read testing
 			createTestStep(
 				testAccWebsiteResourceConfig,
-				"test-acc test one [CREATE_TEST]",
+				"test-acc test two [CREATE_TEST]",
 				"https://example.com",
 				websiteMonitoringConfig,
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.check_for_string.operator", "CONTAINS"),

--- a/internal/provider/website_resource_test.go
+++ b/internal/provider/website_resource_test.go
@@ -47,27 +47,6 @@ func TestAccWebsiteResource(t *testing.T) {
 
 				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.rum"),
 			),
-			createTestStep(
-				testAccWebsiteResourceConfig,
-				"test-acc create without options [CREATE_TEST]",
-				"https://solarwinds.com",
-				websiteMonitoringConfigWithoutAvailabilityOptions,
-				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.0", "HTTP"),
-				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.1", "HTTPS"),
-
-				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.availability.check_for_string"),
-				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.availability.ssl"),
-			),
-			createTestStep(
-				testAccWebsiteResourceConfig,
-				"test-acc create without availability [CREATE_TEST]",
-				"https://solarwinds.com",
-				websiteMonitoringConfigWithoutAvailability,
-				resource.TestCheckResourceAttr("swo_website.test", "monitoring.rum.apdex_time_in_seconds", "4"),
-				resource.TestCheckResourceAttr("swo_website.test", "monitoring.rum.spa", "true"),
-
-				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.availability"),
-			),
 			// ImportState testing
 			{
 				ResourceName:      "swo_website.test",
@@ -85,6 +64,36 @@ func TestAccWebsiteResource(t *testing.T) {
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.0", "HTTP"),
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.1", "HTTPS"),
 			),
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccWebsiteResourceWithoutAvailabilityOptionResources(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			createTestStep(
+				testAccWebsiteResourceConfig,
+				"test-acc create without options [CREATE_TEST]",
+				"https://solarwinds.com",
+				websiteMonitoringConfigWithoutAvailabilityOptions,
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.0", "HTTP"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.1", "HTTPS"),
+
+				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.availability.check_for_string"),
+				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.availability.ssl"),
+			),
+			// ImportState testing
+			{
+				ResourceName:      "swo_website.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
 			createTestStep(
 				testAccWebsiteResourceConfig,
 				"test-acc test update without options [UPDATE_TEST]",
@@ -93,6 +102,35 @@ func TestAccWebsiteResource(t *testing.T) {
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.0", "HTTP"),
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.1", "HTTPS"),
 			),
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccWebsiteResourceWithoutAvailabilityResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			createTestStep(
+				testAccWebsiteResourceConfig,
+				"test-acc create without availability [CREATE_TEST]",
+				"https://solarwinds.com",
+				websiteMonitoringConfigWithoutAvailability,
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.rum.apdex_time_in_seconds", "4"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.rum.spa", "true"),
+
+				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.availability"),
+			),
+			// ImportState testing
+			{
+				ResourceName:      "swo_website.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
 			createTestStep(
 				testAccWebsiteResourceConfig,
 				"test-acc test update without availability [UPDATE_TEST]",

--- a/internal/provider/website_resource_test.go
+++ b/internal/provider/website_resource_test.go
@@ -20,9 +20,32 @@ func TestAccWebsiteResource(t *testing.T) {
 				"https://example.com",
 				websiteMonitoringConfig,
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.check_for_string.operator", "CONTAINS"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.check_for_string.value", "example-string"),
+
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.ssl.enabled", "true"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.ssl.days_prior_to_expiration", "30"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.ssl.ignore_intermediate_certificates", "true"),
+
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.#", "2"),
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.0", "HTTP"),
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.1", "HTTPS"),
+
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.test_interval_in_seconds", "300"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.test_from_location", "REGION"),
+
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.location_options.#", "1"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.location_options.0.type", "REGION"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.location_options.0.value", "NA"),
+
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.platform_options.test_from_all", "false"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.platform_options.platforms.#", "1"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.platform_options.platforms.0", "AWS"),
+
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.custom_headers.#", "1"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.custom_headers.0.name", "Custom-Header-1-Deprecated"),
+				resource.TestCheckResourceAttr("swo_website.test", "monitoring.custom_headers.0.value", "Custom-Value-1-Deprecated"),
+
+				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.rum"),
 			),
 			createTestStep(
 				testAccWebsiteResourceConfig,
@@ -31,6 +54,9 @@ func TestAccWebsiteResource(t *testing.T) {
 				websiteMonitoringConfigWithoutAvailabilityOptions,
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.0", "HTTP"),
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.availability.protocols.1", "HTTPS"),
+
+				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.availability.check_for_string"),
+				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.availability.ssl"),
 			),
 			createTestStep(
 				testAccWebsiteResourceConfig,
@@ -39,6 +65,8 @@ func TestAccWebsiteResource(t *testing.T) {
 				websiteMonitoringConfigWithoutAvailability,
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.rum.apdex_time_in_seconds", "4"),
 				resource.TestCheckResourceAttr("swo_website.test", "monitoring.rum.spa", "true"),
+
+				resource.TestCheckNoResourceAttr("swo_website.test", "monitoring.availability"),
 			),
 			// ImportState testing
 			{

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -56,7 +56,7 @@ type monitoringOptions struct {
 
 type availabilityMonitoring struct {
 	CheckForString        types.Object    `tfsdk:"check_for_string"`
-	SSL                   *sslMonitoring  `tfsdk:"ssl"`
+	SSL                   types.Object    `tfsdk:"ssl"`
 	Protocols             types.List      `tfsdk:"protocols"`
 	TestFromLocation      types.String    `tfsdk:"test_from_location"`
 	TestIntervalInSeconds types.Int64     `tfsdk:"test_interval_in_seconds"`

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -60,7 +60,7 @@ type availabilityMonitoring struct {
 	Protocols             types.List      `tfsdk:"protocols"`
 	TestFromLocation      types.String    `tfsdk:"test_from_location"`
 	TestIntervalInSeconds types.Int64     `tfsdk:"test_interval_in_seconds"`
-	LocationOptions       []probeLocation `tfsdk:"location_options"`
+	LocationOptions       types.Set       `tfsdk:"location_options"`
 	PlatformOptions       platformOptions `tfsdk:"platform_options"`
 	CustomHeaders         types.Set       `tfsdk:"custom_headers"`
 }

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	swoClient "github.com/solarwinds/swo-client-go/pkg/client"
 	"github.com/solarwinds/terraform-provider-swo/internal/validators"
@@ -30,15 +31,37 @@ type probeLocation struct {
 	Value types.String `tfsdk:"value"`
 }
 
+func ProbeLocationAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"type":  types.StringType,
+		"value": types.StringType,
+	}
+}
+
 type platformOptions struct {
 	TestFromAll types.Bool `tfsdk:"test_from_all"`
 	Platforms   types.Set  `tfsdk:"platforms"`
+}
+
+func PlatformOptionsAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"test_from_all": types.BoolType,
+		"platforms":     types.SetType{ElemType: types.StringType},
+	}
 }
 
 type sslMonitoring struct {
 	DaysPriorToExpiration          types.Int64 `tfsdk:"days_prior_to_expiration"`
 	Enabled                        types.Bool  `tfsdk:"enabled"`
 	IgnoreIntermediateCertificates types.Bool  `tfsdk:"ignore_intermediate_certificates"`
+}
+
+func SslMonitoringAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"days_prior_to_expiration":         types.Int64Type,
+		"enabled":                          types.BoolType,
+		"ignore_intermediate_certificates": types.BoolType,
+	}
 }
 
 type websiteMonitoring struct {
@@ -76,9 +99,23 @@ type customHeader struct {
 	Value types.String `tfsdk:"value"`
 }
 
+func CustomHeaderAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":  types.StringType,
+		"value": types.StringType,
+	}
+}
+
 type checkForStringType struct {
 	Operator types.String `tfsdk:"operator"`
 	Value    types.String `tfsdk:"value"`
+}
+
+func CheckForStringTypeAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"operator": types.StringType,
+		"value":    types.StringType,
+	}
 }
 
 func (r *websiteResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -20,10 +20,77 @@ import (
 
 // The main Website Resource model that is derived from the schema.
 type websiteResourceModel struct {
-	Id         types.String       `tfsdk:"id"`
-	Name       types.String       `tfsdk:"name"`
-	Url        types.String       `tfsdk:"url"`
-	Monitoring *websiteMonitoring `tfsdk:"monitoring"`
+	Id         types.String `tfsdk:"id"`
+	Name       types.String `tfsdk:"name"`
+	Url        types.String `tfsdk:"url"`
+	Monitoring types.Object `tfsdk:"monitoring"` //websiteMonitoring
+}
+
+type websiteMonitoring struct {
+	Options       types.Object `tfsdk:"options"`        //monitoringOptions deprecated
+	Availability  types.Object `tfsdk:"availability"`   //availabilityMonitoring
+	Rum           types.Object `tfsdk:"rum"`            //rumMonitoring
+	CustomHeaders types.Set    `tfsdk:"custom_headers"` //deprecated
+}
+
+func WebsiteMonitoringAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"options":        types.ObjectType{AttrTypes: MonitoringOptionsAttributeTypes()},
+		"availability":   types.ObjectType{AttrTypes: AvailabilityMonitoringAttributeTypes()},
+		"rum":            types.ObjectType{AttrTypes: RumMonitoringAttributeTypes()},
+		"custom_headers": types.SetType{ElemType: types.ObjectType{AttrTypes: CustomHeaderAttributeTypes()}},
+	}
+}
+
+// Deprecated: Options are not used anymore
+type monitoringOptions struct {
+	IsAvailabilityActive types.Bool `tfsdk:"is_availability_active"`
+	IsRumActive          types.Bool `tfsdk:"is_rum_active"`
+}
+
+func MonitoringOptionsAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"is_availability_active": types.BoolType,
+		"is_rum_active":          types.BoolType,
+	}
+}
+
+type availabilityMonitoring struct {
+	CheckForString        types.Object `tfsdk:"check_for_string"`
+	SSL                   types.Object `tfsdk:"ssl"`
+	Protocols             types.List   `tfsdk:"protocols"`
+	TestFromLocation      types.String `tfsdk:"test_from_location"`
+	TestIntervalInSeconds types.Int64  `tfsdk:"test_interval_in_seconds"`
+	LocationOptions       types.Set    `tfsdk:"location_options"`
+	PlatformOptions       types.Object `tfsdk:"platform_options"`
+	CustomHeaders         types.Set    `tfsdk:"custom_headers"`
+}
+
+func AvailabilityMonitoringAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"check_for_string":         types.ObjectType{AttrTypes: CheckForStringTypeAttributeTypes()},
+		"ssl":                      types.ObjectType{AttrTypes: SslMonitoringAttributeTypes()},
+		"protocols":                types.ListType{ElemType: types.StringType},
+		"test_from_location":       types.StringType,
+		"test_interval_in_seconds": types.Int64Type,
+		"location_options":         types.SetType{ElemType: types.ObjectType{AttrTypes: ProbeLocationAttributeTypes()}},
+		"platform_options":         types.ObjectType{AttrTypes: PlatformOptionsAttributeTypes()},
+		"custom_headers":           types.SetType{ElemType: types.ObjectType{AttrTypes: CustomHeaderAttributeTypes()}},
+	}
+}
+
+type rumMonitoring struct {
+	ApdexTimeInSeconds types.Int64  `tfsdk:"apdex_time_in_seconds"`
+	Snippet            types.String `tfsdk:"snippet"`
+	Spa                types.Bool   `tfsdk:"spa"`
+}
+
+func RumMonitoringAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"apdex_time_in_seconds": types.Int64Type,
+		"snippet":               types.StringType,
+		"spa":                   types.BoolType,
+	}
 }
 
 type probeLocation struct {
@@ -61,59 +128,6 @@ func SslMonitoringAttributeTypes() map[string]attr.Type {
 		"days_prior_to_expiration":         types.Int64Type,
 		"enabled":                          types.BoolType,
 		"ignore_intermediate_certificates": types.BoolType,
-	}
-}
-
-type websiteMonitoring struct {
-	Options       *monitoringOptions `tfsdk:"options"`
-	Availability  types.Object       `tfsdk:"availability"`
-	Rum           types.Object       `tfsdk:"rum"`
-	CustomHeaders types.Set          `tfsdk:"custom_headers"` //deprecated
-}
-
-// Deprecated: Options are not used anymore
-type monitoringOptions struct {
-	IsAvailabilityActive types.Bool `tfsdk:"is_availability_active"`
-	IsRumActive          types.Bool `tfsdk:"is_rum_active"`
-}
-
-type availabilityMonitoring struct {
-	CheckForString        types.Object `tfsdk:"check_for_string"`
-	SSL                   types.Object `tfsdk:"ssl"`
-	Protocols             types.List   `tfsdk:"protocols"`
-	TestFromLocation      types.String `tfsdk:"test_from_location"`
-	TestIntervalInSeconds types.Int64  `tfsdk:"test_interval_in_seconds"`
-	LocationOptions       types.Set    `tfsdk:"location_options"`
-	PlatformOptions       types.Object `tfsdk:"platform_options"`
-	CustomHeaders         types.Set    `tfsdk:"custom_headers"`
-}
-
-func AvailabilityMonitoringAttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"check_for_string":         types.ObjectType{AttrTypes: CheckForStringTypeAttributeTypes()},
-		"ssl":                      types.ObjectType{AttrTypes: SslMonitoringAttributeTypes()},
-		"protocols":                types.ListType{ElemType: types.StringType},
-		"test_from_location":       types.StringType,
-		"test_interval_in_seconds": types.Int64Type,
-		"location_options":         types.SetType{ElemType: types.ObjectType{AttrTypes: ProbeLocationAttributeTypes()}},
-		"platform_options":         types.ObjectType{AttrTypes: PlatformOptionsAttributeTypes()},
-		"custom_headers":           types.SetType{ElemType: types.ObjectType{AttrTypes: CustomHeaderAttributeTypes()}},
-	}
-}
-
-//todo this needs an attribute mapping
-
-type rumMonitoring struct {
-	ApdexTimeInSeconds types.Int64  `tfsdk:"apdex_time_in_seconds"`
-	Snippet            types.String `tfsdk:"snippet"`
-	Spa                types.Bool   `tfsdk:"spa"`
-}
-
-func RumMonitoringAttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"apdex_time_in_seconds": types.Int64Type,
-		"snippet":               types.StringType,
-		"spa":                   types.BoolType,
 	}
 }
 
@@ -165,9 +179,10 @@ func (r *websiteResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 				Attributes: map[string]schema.Attribute{
 					"options": schema.SingleNestedAttribute{
-						Description:        "The Website monitoring options.",
-						Optional:           true,
-						DeprecationMessage: "Remove this attribute's configuration as it's no longer in use and the attribute will be removed in the next major version of the provider.",
+						Description: "The Website monitoring options.",
+						Optional:    true,
+						DeprecationMessage: "Remove this attribute's configuration as it's no longer in use and the attribute " +
+							"will be removed in the next major version of the provider.",
 						Attributes: map[string]schema.Attribute{
 							"is_availability_active": schema.BoolAttribute{
 								Description:        "Is availability monitoring active?",

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -31,8 +31,8 @@ type probeLocation struct {
 }
 
 type platformOptions struct {
-	TestFromAll types.Bool     `tfsdk:"test_from_all"`
-	Platforms   []types.String `tfsdk:"platforms"`
+	TestFromAll types.Bool `tfsdk:"test_from_all"`
+	Platforms   types.Set  `tfsdk:"platforms"`
 }
 
 type sslMonitoring struct {
@@ -55,14 +55,14 @@ type monitoringOptions struct {
 }
 
 type availabilityMonitoring struct {
-	CheckForString        types.Object    `tfsdk:"check_for_string"`
-	SSL                   types.Object    `tfsdk:"ssl"`
-	Protocols             types.List      `tfsdk:"protocols"`
-	TestFromLocation      types.String    `tfsdk:"test_from_location"`
-	TestIntervalInSeconds types.Int64     `tfsdk:"test_interval_in_seconds"`
-	LocationOptions       types.Set       `tfsdk:"location_options"`
-	PlatformOptions       platformOptions `tfsdk:"platform_options"`
-	CustomHeaders         types.Set       `tfsdk:"custom_headers"`
+	CheckForString        types.Object `tfsdk:"check_for_string"`
+	SSL                   types.Object `tfsdk:"ssl"`
+	Protocols             types.List   `tfsdk:"protocols"`
+	TestFromLocation      types.String `tfsdk:"test_from_location"`
+	TestIntervalInSeconds types.Int64  `tfsdk:"test_interval_in_seconds"`
+	LocationOptions       types.Set    `tfsdk:"location_options"`
+	PlatformOptions       types.Object `tfsdk:"platform_options"`
+	CustomHeaders         types.Set    `tfsdk:"custom_headers"`
 }
 
 type rumMonitoring struct {
@@ -209,7 +209,7 @@ func (r *websiteResource) Schema(ctx context.Context, req resource.SchemaRequest
 										Description: "Test from all platforms?",
 										Required:    true,
 									},
-									"platforms": schema.ListAttribute{
+									"platforms": schema.SetAttribute{
 										Description: "The Website availability monitoring platform options. Valid values are [AWS, AZURE, GOOGLE_CLOUD].",
 										Required:    true,
 										ElementType: types.StringType,

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -45,7 +45,7 @@ type websiteMonitoring struct {
 	Options       *monitoringOptions      `tfsdk:"options"`
 	Availability  *availabilityMonitoring `tfsdk:"availability"`
 	Rum           *rumMonitoring          `tfsdk:"rum"`
-	CustomHeaders *[]customHeader         `tfsdk:"custom_headers"` //deprecated
+	CustomHeaders types.Set               `tfsdk:"custom_headers"` //deprecated
 }
 
 // Deprecated: Options are not used anymore
@@ -62,7 +62,7 @@ type availabilityMonitoring struct {
 	TestIntervalInSeconds types.Int64     `tfsdk:"test_interval_in_seconds"`
 	LocationOptions       []probeLocation `tfsdk:"location_options"`
 	PlatformOptions       platformOptions `tfsdk:"platform_options"`
-	CustomHeaders         *[]customHeader `tfsdk:"custom_headers"`
+	CustomHeaders         types.Set       `tfsdk:"custom_headers"`
 }
 
 type rumMonitoring struct {

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -65,10 +65,10 @@ func SslMonitoringAttributeTypes() map[string]attr.Type {
 }
 
 type websiteMonitoring struct {
-	Options       *monitoringOptions      `tfsdk:"options"`
-	Availability  *availabilityMonitoring `tfsdk:"availability"`
-	Rum           types.Object            `tfsdk:"rum"`
-	CustomHeaders types.Set               `tfsdk:"custom_headers"` //deprecated
+	Options       *monitoringOptions `tfsdk:"options"`
+	Availability  types.Object       `tfsdk:"availability"`
+	Rum           types.Object       `tfsdk:"rum"`
+	CustomHeaders types.Set          `tfsdk:"custom_headers"` //deprecated
 }
 
 // Deprecated: Options are not used anymore
@@ -87,6 +87,21 @@ type availabilityMonitoring struct {
 	PlatformOptions       types.Object `tfsdk:"platform_options"`
 	CustomHeaders         types.Set    `tfsdk:"custom_headers"`
 }
+
+func AvailabilityMonitoringAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"check_for_string":         types.ObjectType{AttrTypes: CheckForStringTypeAttributeTypes()},
+		"ssl":                      types.ObjectType{AttrTypes: SslMonitoringAttributeTypes()},
+		"protocols":                types.ListType{ElemType: types.StringType},
+		"test_from_location":       types.StringType,
+		"test_interval_in_seconds": types.Int64Type,
+		"location_options":         types.SetType{ElemType: types.ObjectType{AttrTypes: ProbeLocationAttributeTypes()}},
+		"platform_options":         types.ObjectType{AttrTypes: PlatformOptionsAttributeTypes()},
+		"custom_headers":           types.SetType{ElemType: types.ObjectType{AttrTypes: CustomHeaderAttributeTypes()}},
+	}
+}
+
+//todo this needs an attribute mapping
 
 type rumMonitoring struct {
 	ApdexTimeInSeconds types.Int64  `tfsdk:"apdex_time_in_seconds"`

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -67,7 +67,7 @@ func SslMonitoringAttributeTypes() map[string]attr.Type {
 type websiteMonitoring struct {
 	Options       *monitoringOptions      `tfsdk:"options"`
 	Availability  *availabilityMonitoring `tfsdk:"availability"`
-	Rum           *rumMonitoring          `tfsdk:"rum"`
+	Rum           types.Object            `tfsdk:"rum"`
 	CustomHeaders types.Set               `tfsdk:"custom_headers"` //deprecated
 }
 
@@ -92,6 +92,14 @@ type rumMonitoring struct {
 	ApdexTimeInSeconds types.Int64  `tfsdk:"apdex_time_in_seconds"`
 	Snippet            types.String `tfsdk:"snippet"`
 	Spa                types.Bool   `tfsdk:"spa"`
+}
+
+func RumMonitoringAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"apdex_time_in_seconds": types.Int64Type,
+		"snippet":               types.StringType,
+		"spa":                   types.BoolType,
+	}
 }
 
 type customHeader struct {

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -55,14 +55,14 @@ type monitoringOptions struct {
 }
 
 type availabilityMonitoring struct {
-	CheckForString        *checkForStringType `tfsdk:"check_for_string"`
-	SSL                   *sslMonitoring      `tfsdk:"ssl"`
-	Protocols             types.List          `tfsdk:"protocols"`
-	TestFromLocation      types.String        `tfsdk:"test_from_location"`
-	TestIntervalInSeconds types.Int64         `tfsdk:"test_interval_in_seconds"`
-	LocationOptions       []probeLocation     `tfsdk:"location_options"`
-	PlatformOptions       platformOptions     `tfsdk:"platform_options"`
-	CustomHeaders         *[]customHeader     `tfsdk:"custom_headers"`
+	CheckForString        types.Object    `tfsdk:"check_for_string"`
+	SSL                   *sslMonitoring  `tfsdk:"ssl"`
+	Protocols             types.List      `tfsdk:"protocols"`
+	TestFromLocation      types.String    `tfsdk:"test_from_location"`
+	TestIntervalInSeconds types.Int64     `tfsdk:"test_interval_in_seconds"`
+	LocationOptions       []probeLocation `tfsdk:"location_options"`
+	PlatformOptions       platformOptions `tfsdk:"platform_options"`
+	CustomHeaders         *[]customHeader `tfsdk:"custom_headers"`
 }
 
 type rumMonitoring struct {


### PR DESCRIPTION
All data types need to be terraform types for dynamic assignment. This required a re-mapping of all resource properties for create, read, and update. In general, use built-in TF methods to convert between Go types and TF types. _The migration of the notification resource has not been performed and will be done in a separate PR._

Convert the known values into the given Go type: 
```
var tfCheckForString checkForStringType
diags = tfAvailability.CheckForString.As(ctx, &tfCheckForString, basetypes.ObjectAsOptions{})
```

Convert the data from the Go types into TF framework types as noted in the documentation for each element type
```
checkForString, diags := types.ObjectValueFrom(ctx, CheckForStringTypeAttributeTypes(), elements)
```