### PR TITLE
Migrate resource notifications to use TF types

### DIFF
--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -13,33 +13,103 @@ A terraform resource for managing notifications.
 ## Example Usage
 
 ```terraform
-resource "swo_notification" "msteams" {
-  title       = "Microsoft teams notification"
-  description = "testing..."
-  type        = "msTeams"
+resource "swo_notification" "amazonsns" {
+  title       = "Amazon SNS notification"
+  description = "This is a description"
+  type        = "amazonsns"
   settings = {
-    msteams = {
-      url = "https://www.office.com/webhook"
+    amazonsns = {
+      topic_arn         = "arn:aws:sns:us-east-1:123456789012:topic"
+      access_key_id     = "KEY_ID"
+      secret_access_key = "SECRET_KEY"
     }
   }
 }
+
+resource "swo_notification" "email" {
+  title       = "Email notification"
+  description = "This is a description"
+  type        = "email"
+  settings = {
+    email = {
+      addresses = [
+        {
+          email = "test1@host.com"
+        },
+        {
+          email = "test2@host.com"
+        },
+      ]
+    }
+  }
+}
+
+resource "swo_notification" "msteams" {
+  title       = "Microsoft Teams notification"
+  description = "This is a description"
+  type        = "msTeams"
+  settings = {
+    msteams = {
+      url = "https://XXX.webhook.office.com/webhookb2/XXXXX"
+    }
+  }
+}
+
 resource "swo_notification" "opsgenie" {
   title       = "OpsGenie notification"
-  description = "testing..."
+  description = "This is a description"
   type        = "opsgenie"
   settings = {
     opsgenie = {
       hostname   = "hostname"
-      apikey     = "123xyz"
-      recipients = "alice"
+      apikey     = "API_KEY"
+      recipients = "on-call recipient"
       teams      = "team1, team2"
       tags       = "tag1, tag2"
     }
   }
 }
+
+resource "swo_notification" "pagerduty" {
+  title       = "PagerDuty notification"
+  description = "This is a description"
+  type        = "pagerduty"
+  settings = {
+    pagerduty = {
+      routing_key = "99999999999999999999999999999999"
+      summary     = "some-summary"
+      dedup_key   = "DEDUP_KEY"
+    }
+  }
+}
+
+resource "swo_notification" "pushover" {
+  title       = "Pushover notification"
+  description = "This is a description"
+  type        = "pushover"
+  settings = {
+    pushover = {
+      app_token = "APP_TOKEN"
+      user_key  = "123xyz"
+    }
+  }
+}
+
+resource "swo_notification" "servicenow" {
+  title       = "ServiceNow notification"
+  description = "This is a description"
+  type        = "servicenow"
+  settings = {
+    servicenow = {
+      app_token = "APP_TOKEN"
+      instance  = "US"
+    }
+  }
+}
+
 resource "swo_notification" "slack" {
   title       = "Slack notification"
-  description = "testing..."
+  description = "This is a description"
   type        = "slack"
   settings = {
     slack = {
@@ -47,73 +117,43 @@ resource "swo_notification" "slack" {
     }
   }
 }
-resource "swo_notification" "pagerduty" {
-  title       = "PagerDuty notification"
-  description = "testing..."
-  type        = "pagerduty"
-  settings = {
-    pagerduty = {
-      routing_key = "99999999999999999999999999999999"
-      summary     = "summary"
-      dedup_key   = "dedup"
-    }
-  }
-}
-resource "swo_notification" "victorops" {
-  title       = "VictorOps notification"
-  description = "testing..."
-  type        = "victorops"
-  settings = {
-    victorops = {
-      api_key     = "xyz"
-      routing_key = "123"
-    }
-  }
-}
-resource "swo_notification" "sms" {
-  title       = "SMS notification"
-  description = "testing..."
-  type        = "sms"
-  settings = {
-    sms = {
-      phone_numbers = "+1 999 999 9999"
-    }
-  }
-}
-resource "swo_notification" "servicenow" {
-  title       = "ServiceNow notification"
-  description = "testing..."
-  type        = "servicenow"
-  settings = {
-    servicenow = {
-      app_token = "xyz"
-      instance  = "US"
-    }
-  }
-}
+
 resource "swo_notification" "swsd" {
   title       = "SolarWinds Service Desk notification"
-  description = "testing..."
+  description = "This is a description"
   type        = "swsd"
   settings = {
     swsd = {
-      app_token = "xyz"
+      app_token = "APP_TOKEN"
       is_eu     = false
     }
   }
 }
 
-resource "swo_notification" "email" {
-  title       = "Email notification"
-  description = "testing..."
-  type        = "email"
+resource "swo_notification" "test_webhook" {
+  title       = "Webhook notification"
+  description = "This is a description"
+  type        = "webhook"
   settings = {
-    email = {
-      addresses = [
-        {
-          email = "bob@xyz.com"
-        },
-      ]
+    webhook = {
+      method            = "GET"
+      url               = "https://webhook.example.com/"
+      auth_header_name  = "X-Request-Id"
+      auth_header_value = "HEADER_VALUE"
+      auth_password     = "AUTH_PASSWORD"
+      auth_type         = "basic"
+      auth_username     = "AUTH_USERNAME"
+    }
+  }
+}
+
+resource "swo_notification" "test_zapier" {
+  title       = "Zapier notification"
+  description = "This is a description"
+  type        = "zapier"
+  settings = {
+    zapier = {
+      url = "https://hooks.zapier.com/hooks/catch/XXX"
     }
   }
 }
@@ -149,9 +189,7 @@ Optional:
 - `pushover` (Attributes) Integration for Sending alerts to Pushover. (see [below for nested schema](#nestedatt--settings--pushover))
 - `servicenow` (Attributes) Integration with SolarWinds Observability creates new incidents based on SolarWinds Observability alerts. (see [below for nested schema](#nestedatt--settings--servicenow))
 - `slack` (Attributes) Integration for sending static alerts to a Slack channel. (see [below for nested schema](#nestedatt--settings--slack))
-- `sms` (Attributes) For sending alerts Through SMS/Text. (see [below for nested schema](#nestedatt--settings--sms))
 - `swsd` (Attributes) Integration with SolarWinds Observability creates new incidents based on SolarWinds Observability alerts. (see [below for nested schema](#nestedatt--settings--swsd))
-- `victorops` (Attributes) Integration for sending events to VictorOps. (see [below for nested schema](#nestedatt--settings--victorops))
 - `webhook` (Attributes) Integration with an existing notification service. (see [below for nested schema](#nestedatt--settings--webhook))
 - `zapier` (Attributes) Integration for sending alerts to Zapier. (see [below for nested schema](#nestedatt--settings--zapier))
 
@@ -213,7 +251,7 @@ Optional:
 
 Required:
 
-- `dedup_key` (String) deduplication key for correlating trigger conditions. (https://support.pagerduty.com/docs/event-management)
+- `dedup_key` (String) Deduplication key for correlating trigger conditions. (https://support.pagerduty.com/docs/event-management)
 - `routing_key` (String, Sensitive) Key for live call routing. (https://support.pagerduty.com/docs/live-call-routing)
 - `summary` (String) A summary of the issue causing the alert to trigger.
 
@@ -244,14 +282,6 @@ Required:
 - `url` (String) Slack Incoming Webhook URL. (https://api.slack.com/messaging/webhooks)
 
 
-<a id="nestedatt--settings--sms"></a>
-### Nested Schema for `settings.sms`
-
-Required:
-
-- `phone_numbers` (String) Phone number alerts will be texted to.
-
-
 <a id="nestedatt--settings--swsd"></a>
 ### Nested Schema for `settings.swsd`
 
@@ -259,18 +289,6 @@ Required:
 
 - `app_token` (String, Sensitive) Token copied from SolarWinds Service Desk
 - `is_eu` (Boolean) Is in the EU.
-
-
-<a id="nestedatt--settings--victorops"></a>
-### Nested Schema for `settings.victorops`
-
-Required:
-
-- `api_key` (String, Sensitive) API Key for a VictorOps integration. (https://help.victorops.com/knowledge-base/api/)
-
-Optional:
-
-- `routing_key` (String, Sensitive) Key for live call routing. (https://help.victorops.com/knowledge-base/routing-keys/)
 
 
 <a id="nestedatt--settings--webhook"></a>

--- a/docs/resources/website.md
+++ b/docs/resources/website.md
@@ -133,7 +133,7 @@ Required:
 
 Required:
 
-- `platforms` (List of String) The Website availability monitoring platform options. Valid values are [AWS, AZURE, GOOGLE_CLOUD].
+- `platforms` (Set of String) The Website availability monitoring platform options. Valid values are [AWS, AZURE, GOOGLE_CLOUD].
 - `test_from_all` (Boolean) Test from all platforms?
 
 

--- a/examples/resources/swo_notification/resource.tf
+++ b/examples/resources/swo_notification/resource.tf
@@ -44,27 +44,6 @@ resource "swo_notification" "pagerduty" {
     }
   }
 }
-resource "swo_notification" "victorops" {
-  title       = "VictorOps notification"
-  description = "testing..."
-  type        = "victorops"
-  settings = {
-    victorops = {
-      api_key     = "xyz"
-      routing_key = "123"
-    }
-  }
-}
-resource "swo_notification" "sms" {
-  title       = "SMS notification"
-  description = "testing..."
-  type        = "sms"
-  settings = {
-    sms = {
-      phone_numbers = "+1 999 999 9999"
-    }
-  }
-}
 resource "swo_notification" "servicenow" {
   title       = "ServiceNow notification"
   description = "testing..."

--- a/examples/resources/swo_notification/resource.tf
+++ b/examples/resources/swo_notification/resource.tf
@@ -1,30 +1,100 @@
-resource "swo_notification" "msteams" {
-  title       = "Microsoft teams notification"
-  description = "testing..."
-  type        = "msTeams"
+resource "swo_notification" "amazonsns" {
+  title       = "Amazon SNS notification"
+  description = "This is a description"
+  type        = "amazonsns"
   settings = {
-    msteams = {
-      url = "https://www.office.com/webhook"
+    amazonsns = {
+      topic_arn = "arn:aws:sns:us-east-1:123456789012:topic"
+      access_key_id = "KEY_ID"
+      secret_access_key = "SECRET_KEY"
     }
   }
 }
+
+resource "swo_notification" "email" {
+  title       = "Email notification"
+  description = "This is a description"
+  type        = "email"
+  settings = {
+    email = {
+      addresses = [
+        {
+          email = "test1@host.com"
+        },
+        {
+          email = "test2@host.com"
+        },
+      ]
+    }
+  }
+}
+
+resource "swo_notification" "msteams" {
+  title       = "Microsoft Teams notification"
+  description = "This is a description"
+  type        = "msTeams"
+  settings = {
+    msteams = {
+      url = "https://XXX.webhook.office.com/webhookb2/XXXXX"
+    }
+  }
+}
+
 resource "swo_notification" "opsgenie" {
   title       = "OpsGenie notification"
-  description = "testing..."
+  description = "This is a description"
   type        = "opsgenie"
   settings = {
     opsgenie = {
       hostname   = "hostname"
-      apikey     = "123xyz"
-      recipients = "alice"
+      apikey     = "API_KEY"
+      recipients = "on-call recipient"
       teams      = "team1, team2"
       tags       = "tag1, tag2"
     }
   }
 }
+
+resource "swo_notification" "pagerduty" {
+  title       = "PagerDuty notification"
+  description = "This is a description"
+  type        = "pagerduty"
+  settings = {
+    pagerduty = {
+      routing_key = "99999999999999999999999999999999"
+      summary     = "some-summary"
+      dedup_key   = "DEDUP_KEY"
+    }
+  }
+}
+
+resource "swo_notification" "pushover" {
+  title       = "Pushover notification"
+  description = "This is a description"
+  type        = "pushover"
+  settings = {
+    pushover = {
+      app_token = "APP_TOKEN"
+      user_key  = "123xyz"
+    }
+  }
+}
+
+resource "swo_notification" "servicenow" {
+  title       = "ServiceNow notification"
+  description = "This is a description"
+  type        = "servicenow"
+  settings = {
+    servicenow = {
+      app_token = "APP_TOKEN"
+      instance  = "US"
+    }
+  }
+}
+
 resource "swo_notification" "slack" {
   title       = "Slack notification"
-  description = "testing..."
+  description = "This is a description"
   type        = "slack"
   settings = {
     slack = {
@@ -32,52 +102,43 @@ resource "swo_notification" "slack" {
     }
   }
 }
-resource "swo_notification" "pagerduty" {
-  title       = "PagerDuty notification"
-  description = "testing..."
-  type        = "pagerduty"
-  settings = {
-    pagerduty = {
-      routing_key = "99999999999999999999999999999999"
-      summary     = "summary"
-      dedup_key   = "dedup"
-    }
-  }
-}
-resource "swo_notification" "servicenow" {
-  title       = "ServiceNow notification"
-  description = "testing..."
-  type        = "servicenow"
-  settings = {
-    servicenow = {
-      app_token = "xyz"
-      instance  = "US"
-    }
-  }
-}
+
 resource "swo_notification" "swsd" {
   title       = "SolarWinds Service Desk notification"
-  description = "testing..."
+  description = "This is a description"
   type        = "swsd"
   settings = {
     swsd = {
-      app_token = "xyz"
+      app_token = "APP_TOKEN"
       is_eu     = false
     }
   }
 }
 
-resource "swo_notification" "email" {
-  title       = "Email notification"
-  description = "testing..."
-  type        = "email"
+resource "swo_notification" "test_webhook" {
+  title       = "Webhook notification"
+  description = "This is a description"
+  type        = "webhook"
   settings = {
-    email = {
-      addresses = [
-        {
-          email = "bob@xyz.com"
-        },
-      ]
+    webhook = {
+      method = "GET"
+      url    = "https://webhook.example.com/"
+      auth_header_name = "X-Request-Id"
+      auth_header_value = "HEADER_VALUE"
+      auth_password = "AUTH_PASSWORD"
+      auth_type = "basic"
+      auth_username = "AUTH_USERNAME"
+    }
+  }
+}
+
+resource "swo_notification" "test_zapier" {
+  title       = "Zapier notification"
+  description = "This is a description"
+  type        = "zapier"
+  settings = {
+    zapier = {
+      url = "https://hooks.zapier.com/hooks/catch/XXX"
     }
   }
 }

--- a/examples/resources/swo_notification/resource.tf
+++ b/examples/resources/swo_notification/resource.tf
@@ -4,8 +4,8 @@ resource "swo_notification" "amazonsns" {
   type        = "amazonsns"
   settings = {
     amazonsns = {
-      topic_arn = "arn:aws:sns:us-east-1:123456789012:topic"
-      access_key_id = "KEY_ID"
+      topic_arn         = "arn:aws:sns:us-east-1:123456789012:topic"
+      access_key_id     = "KEY_ID"
       secret_access_key = "SECRET_KEY"
     }
   }
@@ -121,13 +121,13 @@ resource "swo_notification" "test_webhook" {
   type        = "webhook"
   settings = {
     webhook = {
-      method = "GET"
-      url    = "https://webhook.example.com/"
-      auth_header_name = "X-Request-Id"
+      method            = "GET"
+      url               = "https://webhook.example.com/"
+      auth_header_name  = "X-Request-Id"
       auth_header_value = "HEADER_VALUE"
-      auth_password = "AUTH_PASSWORD"
-      auth_type = "basic"
-      auth_username = "AUTH_USERNAME"
+      auth_password     = "AUTH_PASSWORD"
+      auth_type         = "basic"
+      auth_username     = "AUTH_USERNAME"
     }
   }
 }

--- a/internal/provider/notificationSettings.go
+++ b/internal/provider/notificationSettings.go
@@ -289,19 +289,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				return nil
 			}
 
-			var c []clientEmailAddress
-			c = convertArray(addresses, func(h notificationSettingsEmailAddress) clientEmailAddress {
+			var clientAddresses []clientEmailAddress
+			clientAddresses = convertArray(addresses, func(h notificationSettingsEmailAddress) clientEmailAddress {
 				return clientEmailAddress{
 					Id:    h.Id.ValueStringPointer(),
 					Email: h.Email.ValueString(),
 				}
 			})
 			return clientEmail{
-				Addresses: c,
+				Addresses: clientAddresses,
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientEmail](settings)
+			settingsStruct, err := toSettingsStruct[clientEmail](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'email' settings: %s", err))
@@ -309,13 +309,13 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 
 			var elements []attr.Value
-			for _, a := range s.Addresses {
+			for _, ss := range settingsStruct.Addresses {
 				objectValue, d := types.ObjectValueFrom(
 					ctx,
 					EmailAddressAttributeTypes(),
 					notificationSettingsEmailAddress{
-						Id:    types.StringPointerValue(a.Id),
-						Email: types.StringValue(a.Email),
+						Id:    types.StringPointerValue(ss.Id),
+						Email: types.StringValue(ss.Email),
 					},
 				)
 				if d.HasError() {
@@ -325,20 +325,20 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				elements = append(elements, objectValue)
 			}
 
-			setValue, d2 := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: EmailAddressAttributeTypes()}, elements)
-			if d2.HasError() {
-				diags.Append(d2...)
+			setValue, d := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: EmailAddressAttributeTypes()}, elements)
+			if d.HasError() {
+				diags.Append(d...)
 				return
 			}
 			var email notificationSettingsEmail
 			m.Email.As(ctx, &email, basetypes.ObjectAsOptions{})
 			email.Addresses = setValue
-			o, d3 := types.ObjectValueFrom(ctx, EmailAttributeTypes(), email)
-			if d3.HasError() {
-				diags.Append(d3...)
+			tfObject, d := types.ObjectValueFrom(ctx, EmailAttributeTypes(), email)
+			if d.HasError() {
+				diags.Append(d...)
 				return
 			}
-			m.Email = o
+			m.Email = tfObject
 		},
 	},
 	"slack": {
@@ -354,18 +354,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientSlack](settings)
+			settingsStruct, err := toSettingsStruct[clientSlack](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'slack' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, SlackAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, SlackAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 				return
 			}
-			m.Slack = o
+			m.Slack = tfObject
 		},
 	},
 	"pagerduty": {
@@ -382,18 +382,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientPagerDuty](settings)
+			settingsStruct, err := toSettingsStruct[clientPagerDuty](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'pagerduty' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, PagerDutyAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, PagerDutyAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 				return
 			}
-			m.PagerDuty = o
+			m.PagerDuty = tfObject
 		},
 	},
 	"webhook": {
@@ -415,18 +415,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientWebhook](settings)
+			settingsStruct, err := toSettingsStruct[clientWebhook](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'webhook' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, WebhookAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, WebhookAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 				return
 			}
-			m.Webhook = o
+			m.Webhook = tfObject
 		},
 	},
 	"opsgenie": {
@@ -446,18 +446,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientOpsGenie](settings)
+			settingsStruct, err := toSettingsStruct[clientOpsGenie](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'opsgenie' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, OpsGenieAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, OpsGenieAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 				return
 			}
-			m.OpsGenie = o
+			m.OpsGenie = tfObject
 		},
 	},
 	"amazonsns": {
@@ -475,18 +475,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientAmazonSNS](settings)
+			settingsStruct, err := toSettingsStruct[clientAmazonSNS](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'amazonsns' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, AmazonSNSAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, AmazonSNSAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 				return
 			}
-			m.AmazonSNS = o
+			m.AmazonSNS = tfObject
 		},
 	},
 	"zapier": {
@@ -502,17 +502,17 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientZapier](settings)
+			settingsStruct, err := toSettingsStruct[clientZapier](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'zapier' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, ZapierAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, ZapierAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 			}
-			m.Zapier = o
+			m.Zapier = tfObject
 		},
 	},
 	"msTeams": {
@@ -528,18 +528,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientMsTeams](settings)
+			settingsStruct, err := toSettingsStruct[clientMsTeams](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'msTeams' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, MsTeamsAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, MsTeamsAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 				return
 			}
-			m.MsTeams = o
+			m.MsTeams = tfObject
 		},
 	},
 	"pushover": {
@@ -556,18 +556,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientPushover](settings)
+			settingsStruct, err := toSettingsStruct[clientPushover](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'pushover' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, PushoverAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, PushoverAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 				return
 			}
-			m.Pushover = o
+			m.Pushover = tfObject
 		},
 	},
 	"swsd": {
@@ -584,18 +584,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientSolarWindsServiceDesk](settings)
+			settingsStruct, err := toSettingsStruct[clientSolarWindsServiceDesk](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'swsd' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, SolarWindsServiceDeskAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, SolarWindsServiceDeskAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 				return
 			}
-			m.SolarWindsServiceDesk = o
+			m.SolarWindsServiceDesk = tfObject
 		},
 	},
 	"servicenow": {
@@ -612,18 +612,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
-			s, err := toSettingsStruct[clientServiceNow](settings)
+			settingsStruct, err := toSettingsStruct[clientServiceNow](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'servicenow' settings: %s", err))
 				return
 			}
-			o, d := types.ObjectValueFrom(ctx, ServiceNowAttributeTypes(), s)
+			tfObject, d := types.ObjectValueFrom(ctx, ServiceNowAttributeTypes(), settingsStruct)
 			if d.HasError() {
 				diags.Append(d...)
 				return
 			}
-			m.ServiceNow = o
+			m.ServiceNow = tfObject
 		},
 	},
 }
@@ -670,12 +670,12 @@ func (m *notificationResourceModel) SetSettings(settings *any, ctx context.Conte
 			return
 		}
 
-		o, d := types.ObjectValueFrom(ctx, NotificationSettingsAttributeTypes(), model)
+		tfSettings, d := types.ObjectValueFrom(ctx, NotificationSettingsAttributeTypes(), model)
 		if d.HasError() {
 			diags.Append(d...)
 			return
 		}
-		m.Settings = o
+		m.Settings = tfSettings
 	} else {
 		diags.AddError("Unsupported Notification Type Error",
 			fmt.Sprintf("%s: %s", errUnsupportedNotificationType, m.Type.ValueString()))

--- a/internal/provider/notificationSettings.go
+++ b/internal/provider/notificationSettings.go
@@ -326,8 +326,9 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 					Email: h.Email.ValueString(),
 				}
 			})
-			o := clientEmail{Addresses: c}
-			return o
+			return clientEmail{
+				Addresses: c,
+			}
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			d, err := toSettingsStruct[clientEmail](settings)
@@ -364,10 +365,9 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var slack notificationSettingsSlack
 			m.Slack.As(ctx, &slack, basetypes.ObjectAsOptions{})
-			c := clientSlack{
+			return clientSlack{
 				Url: slack.Url.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientSlack](settings)
@@ -380,12 +380,11 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var pagerDuty notificationSettingsPagerDuty
 			m.PagerDuty.As(ctx, &pagerDuty, basetypes.ObjectAsOptions{})
-			c := clientPagerDuty{
+			return clientPagerDuty{
 				RoutingKey: pagerDuty.RoutingKey.ValueString(),
 				Summary:    pagerDuty.Summary.ValueString(),
 				DedupKey:   pagerDuty.DedupKey.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientPagerDuty](settings)
@@ -398,7 +397,7 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var webhook notificationSettingsWebhook
 			m.Webhook.As(ctx, &webhook, basetypes.ObjectAsOptions{})
-			c := clientWebhook{
+			return clientWebhook{
 				Url:             webhook.Url.ValueString(),
 				Method:          webhook.Method.ValueString(),
 				AuthType:        webhook.AuthType.ValueString(),
@@ -407,7 +406,6 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				AuthHeaderName:  webhook.AuthHeaderName.ValueString(),
 				AuthHeaderValue: webhook.AuthHeaderValue.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientWebhook](settings)
@@ -420,11 +418,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var victorOps notificationSettingsVictorOps
 			m.VictorOps.As(ctx, &victorOps, basetypes.ObjectAsOptions{})
-			c := clientVictorOps{
+			return clientVictorOps{
 				ApiKey:     victorOps.ApiKey.ValueString(),
 				RoutingKey: victorOps.RoutingKey.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientVictorOps](settings)
@@ -437,14 +434,13 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var opsGenie notificationSettingsOpsGenie
 			m.OpsGenie.As(ctx, &opsGenie, basetypes.ObjectAsOptions{})
-			c := clientOpsGenie{
+			return clientOpsGenie{
 				HostName:   opsGenie.HostName.ValueString(),
 				ApiKey:     opsGenie.ApiKey.ValueString(),
 				Recipients: opsGenie.Recipients.ValueString(),
 				Teams:      opsGenie.Teams.ValueString(),
 				Tags:       opsGenie.Tags.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientOpsGenie](settings)
@@ -457,12 +453,11 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var amazonSns notificationSettingsAmazonSNS
 			m.AmazonSNS.As(ctx, &amazonSns, basetypes.ObjectAsOptions{})
-			c := clientAmazonSNS{
+			return clientAmazonSNS{
 				TopicARN:        amazonSns.TopicARN.ValueString(),
 				AccessKeyID:     amazonSns.AccessKeyID.ValueString(),
 				SecretAccessKey: amazonSns.SecretAccessKey.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientAmazonSNS](settings)
@@ -475,10 +470,9 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var zapier notificationSettingsZapier
 			m.Zapier.As(ctx, &zapier, basetypes.ObjectAsOptions{})
-			c := clientZapier{
+			return clientZapier{
 				Url: zapier.Url.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientZapier](settings)
@@ -491,10 +485,9 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var msTeams notificationSettingsMsTeams
 			m.MsTeams.As(ctx, &msTeams, basetypes.ObjectAsOptions{})
-			c := clientMsTeams{
+			return clientMsTeams{
 				Url: msTeams.Url.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientMsTeams](settings)
@@ -507,11 +500,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var pushover notificationSettingsPushover
 			m.Pushover.As(ctx, &pushover, basetypes.ObjectAsOptions{})
-			c := clientPushover{
+			return clientPushover{
 				UserKey:  pushover.UserKey.ValueString(),
 				AppToken: pushover.AppToken.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientPushover](settings)
@@ -524,10 +516,9 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var sms notificationSettingsSms
 			m.Sms.As(ctx, &sms, basetypes.ObjectAsOptions{})
-			c := clientSms{
+			return clientSms{
 				PhoneNumbers: sms.PhoneNumbers.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientSms](settings)
@@ -540,11 +531,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var swoServiceDesk notificationSettingsSolarWindsServiceDesk
 			m.SolarWindsServiceDesk.As(ctx, &swoServiceDesk, basetypes.ObjectAsOptions{})
-			c := clientSolarWindsServiceDesk{
+			return clientSolarWindsServiceDesk{
 				AppToken: swoServiceDesk.AppToken.ValueString(),
 				IsEU:     swoServiceDesk.IsEU.ValueBool(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientSolarWindsServiceDesk](settings)
@@ -557,11 +547,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var serviceNow notificationSettingsServiceNow
 			m.ServiceNow.As(ctx, &serviceNow, basetypes.ObjectAsOptions{})
-			c := clientServiceNow{
+			return clientServiceNow{
 				AppToken: serviceNow.AppToken.ValueString(),
 				Instance: serviceNow.Instance.ValueString(),
 			}
-			return c
 		},
 		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
 			s, err := toSettingsStruct[clientServiceNow](settings)

--- a/internal/provider/notificationSettings.go
+++ b/internal/provider/notificationSettings.go
@@ -46,7 +46,7 @@ func NotificationSettingsAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsEmail struct {
-	Addresses types.Set `tfsdk:"addresses" json:"addresses"`
+	Addresses types.Set `tfsdk:"addresses"`
 }
 
 type clientEmail struct {
@@ -60,8 +60,8 @@ func EmailAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsEmailAddress struct {
-	Id    types.String `tfsdk:"id" json:"id"`
-	Email types.String `tfsdk:"email" json:"email"`
+	Id    types.String `tfsdk:"id"`
+	Email types.String `tfsdk:"email"`
 }
 
 type clientEmailAddress struct {
@@ -77,11 +77,11 @@ func EmailAddressAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsOpsGenie struct {
-	HostName   types.String `tfsdk:"hostname" json:"hostname"`
-	ApiKey     types.String `tfsdk:"api_key" json:"apiKey"`
-	Recipients types.String `tfsdk:"recipients" json:"recipients"`
-	Teams      types.String `tfsdk:"teams" json:"teams"`
-	Tags       types.String `tfsdk:"tags" json:"tags"`
+	HostName   types.String `tfsdk:"hostname"`
+	ApiKey     types.String `tfsdk:"api_key"`
+	Recipients types.String `tfsdk:"recipients"`
+	Teams      types.String `tfsdk:"teams"`
+	Tags       types.String `tfsdk:"tags"`
 }
 
 type clientOpsGenie struct {
@@ -103,7 +103,7 @@ func OpsGenieAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsSlack struct {
-	Url types.String `tfsdk:"url" json:"url"`
+	Url types.String `tfsdk:"url"`
 }
 
 type clientSlack struct {
@@ -117,7 +117,7 @@ func SlackAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsMsTeams struct {
-	Url types.String `tfsdk:"url" json:"url"`
+	Url types.String `tfsdk:"url"`
 }
 
 type clientMsTeams struct {
@@ -131,9 +131,9 @@ func MsTeamsAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsPagerDuty struct {
-	RoutingKey types.String `tfsdk:"routing_key" json:"routingKey"`
-	Summary    types.String `tfsdk:"summary" json:"summary"`
-	DedupKey   types.String `tfsdk:"dedup_key" json:"dedupKey"`
+	RoutingKey types.String `tfsdk:"routing_key"`
+	Summary    types.String `tfsdk:"summary"`
+	DedupKey   types.String `tfsdk:"dedup_key"`
 }
 
 type clientPagerDuty struct {
@@ -151,13 +151,13 @@ func PagerDutyAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsWebhook struct {
-	Url             types.String `tfsdk:"url" json:"url"`
-	Method          types.String `tfsdk:"method" json:"method"`
-	AuthType        types.String `tfsdk:"auth_type" json:"authType"`
-	AuthUsername    types.String `tfsdk:"auth_username" json:"authUsername"`
-	AuthPassword    types.String `tfsdk:"auth_password" json:"authPassword"`
-	AuthHeaderName  types.String `tfsdk:"auth_header_name" json:"authHeaderName"`
-	AuthHeaderValue types.String `tfsdk:"auth_header_value" json:"authHeaderValue"`
+	Url             types.String `tfsdk:"url" `
+	Method          types.String `tfsdk:"method"`
+	AuthType        types.String `tfsdk:"auth_type"`
+	AuthUsername    types.String `tfsdk:"auth_username"`
+	AuthPassword    types.String `tfsdk:"auth_password"`
+	AuthHeaderName  types.String `tfsdk:"auth_header_name"`
+	AuthHeaderValue types.String `tfsdk:"auth_header_value"`
 }
 
 type clientWebhook struct {
@@ -183,9 +183,9 @@ func WebhookAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsAmazonSNS struct {
-	TopicARN        types.String `tfsdk:"topic_arn" json:"topicARN"`
-	AccessKeyID     types.String `tfsdk:"access_key_id" json:"accessKeyId"`
-	SecretAccessKey types.String `tfsdk:"secret_access_key" json:"secretAccessKey"`
+	TopicARN        types.String `tfsdk:"topic_arn"`
+	AccessKeyID     types.String `tfsdk:"access_key_id"`
+	SecretAccessKey types.String `tfsdk:"secret_access_key"`
 }
 
 type clientAmazonSNS struct {
@@ -203,7 +203,7 @@ func AmazonSNSAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsZapier struct {
-	Url types.String `tfsdk:"url" json:"url"`
+	Url types.String `tfsdk:"url"`
 }
 
 type clientZapier struct {
@@ -217,8 +217,8 @@ func ZapierAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsPushover struct {
-	UserKey  types.String `tfsdk:"user_key" json:"userKey"`
-	AppToken types.String `tfsdk:"app_token" json:"appToken"`
+	UserKey  types.String `tfsdk:"user_key"`
+	AppToken types.String `tfsdk:"app_token"`
 }
 
 type clientPushover struct {
@@ -234,8 +234,8 @@ func PushoverAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsSolarWindsServiceDesk struct {
-	AppToken types.String `tfsdk:"app_token" json:"appToken"`
-	IsEU     types.Bool   `tfsdk:"is_eu" json:"isEu"`
+	AppToken types.String `tfsdk:"app_token"`
+	IsEU     types.Bool   `tfsdk:"is_eu"`
 }
 
 type clientSolarWindsServiceDesk struct {
@@ -251,8 +251,8 @@ func SolarWindsServiceDeskAttributeTypes() map[string]attr.Type {
 }
 
 type notificationSettingsServiceNow struct {
-	AppToken types.String `tfsdk:"app_token" json:"appToken"`
-	Instance types.String `tfsdk:"instance" json:"instance"`
+	AppToken types.String `tfsdk:"app_token"`
+	Instance types.String `tfsdk:"instance"`
 }
 
 type clientServiceNow struct {

--- a/internal/provider/notificationSettings.go
+++ b/internal/provider/notificationSettings.go
@@ -9,16 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"log"
 )
 
 var (
 	errUnsupportedNotificationType = errors.New("unsupported notification type")
 )
-
-func newUnsupportedNotificationTypeError(notificationType string) error {
-	return fmt.Errorf("%w: %s", errUnsupportedNotificationType, notificationType)
-}
 
 type notificationSettings struct {
 	Email                 types.Object `tfsdk:"email"`
@@ -275,7 +270,7 @@ func ServiceNowAttributeTypes() map[string]attr.Type {
 type notificationSettingsAccessor struct {
 	/// Translates the tf type notification model into the json client model
 	Get func(m *notificationSettings, ctx context.Context, diags *diag.Diagnostics) any
-	Set func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error
+	Set func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics)
 }
 
 var settingsAccessors = map[string]notificationSettingsAccessor{
@@ -305,12 +300,12 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				Addresses: c,
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientEmail](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'email' settings: %s", err))
-				return err
+				return
 			}
 
 			var elements []attr.Value
@@ -325,7 +320,7 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				)
 				if d.HasError() {
 					diags.Append(d...)
-					return nil
+					return
 				}
 				elements = append(elements, objectValue)
 			}
@@ -333,7 +328,7 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			setValue, d2 := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: EmailAddressAttributeTypes()}, elements)
 			if d2.HasError() {
 				diags.Append(d2...)
-				return nil
+				return
 			}
 			var email notificationSettingsEmail
 			m.Email.As(ctx, &email, basetypes.ObjectAsOptions{})
@@ -341,10 +336,9 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			o, d3 := types.ObjectValueFrom(ctx, EmailAttributeTypes(), email)
 			if d3.HasError() {
 				diags.Append(d3...)
-				return nil
+				return
 			}
 			m.Email = o
-			return err
 		},
 	},
 	"slack": {
@@ -359,20 +353,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				Url: slack.Url.ValueString(),
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientSlack](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'slack' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, SlackAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
+				return
 			}
 			m.Slack = o
-			return err
 		},
 	},
 	"pagerduty": {
@@ -388,20 +381,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				DedupKey:   pagerDuty.DedupKey.ValueString(),
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientPagerDuty](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'pagerduty' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, PagerDutyAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
+				return
 			}
 			m.PagerDuty = o
-			return err
 		},
 	},
 	"webhook": {
@@ -422,20 +414,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				AuthHeaderValue: webhook.AuthHeaderValue.ValueString(),
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientWebhook](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'webhook' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, WebhookAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
+				return
 			}
 			m.Webhook = o
-			return err
 		},
 	},
 	"opsgenie": {
@@ -454,20 +445,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientOpsGenie](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'opsgenie' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, OpsGenieAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
+				return
 			}
 			m.OpsGenie = o
-			return err
 		},
 	},
 	"amazonsns": {
@@ -484,20 +474,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				SecretAccessKey: amazonSns.SecretAccessKey.ValueString(),
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientAmazonSNS](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'amazonsns' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, AmazonSNSAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
+				return
 			}
 			m.AmazonSNS = o
-			return err
 		},
 	},
 	"zapier": {
@@ -512,20 +501,18 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				Url: zapier.Url.ValueString(),
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientZapier](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'zapier' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, ZapierAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
 			}
 			m.Zapier = o
-			return err
 		},
 	},
 	"msTeams": {
@@ -540,20 +527,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				Url: msTeams.Url.ValueString(),
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientMsTeams](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'msTeams' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, MsTeamsAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
+				return
 			}
 			m.MsTeams = o
-			return err
 		},
 	},
 	"pushover": {
@@ -569,20 +555,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				AppToken: pushover.AppToken.ValueString(),
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientPushover](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'pushover' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, PushoverAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
+				return
 			}
 			m.Pushover = o
-			return err
 		},
 	},
 	"swsd": {
@@ -598,20 +583,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				IsEU:     swoServiceDesk.IsEU.ValueBool(),
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientSolarWindsServiceDesk](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'swsd' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, SolarWindsServiceDeskAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
+				return
 			}
 			m.SolarWindsServiceDesk = o
-			return err
 		},
 	},
 	"servicenow": {
@@ -627,20 +611,19 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 				Instance: serviceNow.Instance.ValueString(),
 			}
 		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) error {
+		Set: func(m *notificationSettings, settings any, ctx context.Context, diags *diag.Diagnostics) {
 			s, err := toSettingsStruct[clientServiceNow](settings)
 			if err != nil {
 				diags.AddError("Marshal Error",
 					fmt.Sprintf("Error marshalling 'servicenow' settings: %s", err))
-				return err
+				return
 			}
 			o, d := types.ObjectValueFrom(ctx, ServiceNowAttributeTypes(), s)
 			if d.HasError() {
 				diags.Append(d...)
-				return nil
+				return
 			}
 			m.ServiceNow = o
-			return err
 		},
 	},
 }
@@ -661,7 +644,7 @@ func toSettingsStruct[T any](settings any) (*T, error) {
 	return &concreteSettings, nil
 }
 
-func (m *notificationResourceModel) SetSettings(settings *any, ctx context.Context, diags *diag.Diagnostics) error {
+func (m *notificationResourceModel) SetSettings(settings *any, ctx context.Context, diags *diag.Diagnostics) {
 
 	if accessor, found := settingsAccessors[m.Type.ValueString()]; found {
 		if m.Settings.IsNull() {
@@ -682,24 +665,20 @@ func (m *notificationResourceModel) SetSettings(settings *any, ctx context.Conte
 			ServiceNow:            types.ObjectNull(ServiceNowAttributeTypes()),
 		}
 
-		err := accessor.Set(&model, settings, ctx, diags) //todo don't return error and diags
-		if err != nil {
-			return err
-		}
+		accessor.Set(&model, settings, ctx, diags)
 		if diags.HasError() {
-			return nil
+			return
 		}
 
 		o, d := types.ObjectValueFrom(ctx, NotificationSettingsAttributeTypes(), model)
 		if d.HasError() {
 			diags.Append(d...)
-			return nil
+			return
 		}
 		m.Settings = o
-		return nil
-
 	} else {
-		return newUnsupportedNotificationTypeError(m.Type.ValueString())
+		diags.AddError("Unsupported Notification Type Error",
+			fmt.Sprintf("%s: %s", errUnsupportedNotificationType, m.Type.ValueString()))
 	}
 }
 
@@ -722,8 +701,9 @@ func (m *notificationResourceModel) GetSettings(ctx context.Context, diags *diag
 			return nil
 		}
 		return clientSettings
+	} else {
+		diags.AddError("Unsupported Notification Type Error",
+			fmt.Sprintf("%s: %s", errUnsupportedNotificationType, m.Type.ValueString()))
+		return nil
 	}
-
-	log.Printf("unsupported notification type. got %s", m.Type.ValueString())
-	return nil
 }

--- a/internal/provider/notificationSettings.go
+++ b/internal/provider/notificationSettings.go
@@ -37,9 +37,19 @@ type notificationSettings struct {
 
 func NotificationSettingsAttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"port":             types.Int64Type,
-		"string_to_expect": types.StringType,
-		"string_to_send":   types.StringType,
+		"email":      types.ObjectType{AttrTypes: EmailAttributeTypes()},
+		"slack":      types.ObjectType{AttrTypes: SlackAttributeTypes()},
+		"pagerduty":  types.ObjectType{AttrTypes: PagerDutyAttributeTypes()},
+		"msteams":    types.ObjectType{AttrTypes: MsTeamsAttributeTypes()},
+		"webhook":    types.ObjectType{AttrTypes: WebhookAttributeTypes()},
+		"victorops":  types.ObjectType{AttrTypes: VictorOpsAttributeTypes()},
+		"opsgenie":   types.ObjectType{AttrTypes: OpsGenieAttributeTypes()},
+		"amazonsns":  types.ObjectType{AttrTypes: AmazonSNSAttributeTypes()},
+		"zapier":     types.ObjectType{AttrTypes: ZapierAttributeTypes()},
+		"pushover":   types.ObjectType{AttrTypes: PushoverAttributeTypes()},
+		"sms":        types.ObjectType{AttrTypes: SmsAttributeTypes()},
+		"swsd":       types.ObjectType{AttrTypes: SolarWindsServiceDeskAttributeTypes()},
+		"servicenow": types.ObjectType{AttrTypes: ServiceNowAttributeTypes()},
 	}
 }
 
@@ -51,6 +61,12 @@ type clientEmail struct {
 	Addresses []clientEmailAddress `tfsdk:"addresses" json:"addresses"`
 }
 
+func EmailAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"addresses": types.SetType{ElemType: types.ObjectType{AttrTypes: EmailAddressAttributeTypes()}},
+	}
+}
+
 type notificationSettingsEmailAddress struct {
 	Id    types.String `tfsdk:"id" json:"id"`
 	Email types.String `tfsdk:"email" json:"email"`
@@ -59,6 +75,13 @@ type notificationSettingsEmailAddress struct {
 type clientEmailAddress struct {
 	Id    *string `tfsdk:"id" json:"id"`
 	Email string  `tfsdk:"email" json:"email"`
+}
+
+func EmailAddressAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":    types.StringType,
+		"email": types.StringType,
+	}
 }
 
 type notificationSettingsOpsGenie struct {
@@ -77,12 +100,28 @@ type clientOpsGenie struct {
 	Tags       string `tfsdk:"tags" json:"tags"`
 }
 
+func OpsGenieAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"hostname":   types.StringType,
+		"api_key":    types.StringType,
+		"recipients": types.StringType,
+		"teams":      types.StringType,
+		"tags":       types.StringType,
+	}
+}
+
 type notificationSettingsSms struct {
 	PhoneNumbers types.String `tfsdk:"phone_numbers" json:"phoneNumbers"`
 }
 
 type clientSms struct {
 	PhoneNumbers string `tfsdk:"phone_numbers" json:"phoneNumbers"`
+}
+
+func SmsAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"phone_numbers": types.StringType,
+	}
 }
 
 type notificationSettingsSlack struct {
@@ -93,12 +132,24 @@ type clientSlack struct {
 	Url string `tfsdk:"url" json:"url"`
 }
 
+func SlackAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"url": types.StringType,
+	}
+}
+
 type notificationSettingsMsTeams struct {
 	Url types.String `tfsdk:"url" json:"url"`
 }
 
 type clientMsTeams struct {
 	Url string `tfsdk:"url" json:"url"`
+}
+
+func MsTeamsAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"url": types.StringType,
+	}
 }
 
 type notificationSettingsPagerDuty struct {
@@ -111,6 +162,14 @@ type clientPagerDuty struct {
 	RoutingKey string `tfsdk:"routing_key" json:"routingKey"`
 	Summary    string `tfsdk:"summary" json:"summary"`
 	DedupKey   string `tfsdk:"dedup_key" json:"dedupKey"`
+}
+
+func PagerDutyAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"routing_key": types.StringType,
+		"summary":     types.StringType,
+		"dedup_key":   types.StringType,
+	}
 }
 
 type notificationSettingsWebhook struct {
@@ -133,6 +192,18 @@ type clientWebhook struct {
 	AuthHeaderValue string `tfsdk:"auth_header_value" json:"authHeaderValue"`
 }
 
+func WebhookAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"url":               types.StringType,
+		"method":            types.StringType,
+		"auth_type":         types.StringType,
+		"auth_username":     types.StringType,
+		"auth_password":     types.StringType,
+		"auth_header_name":  types.StringType,
+		"auth_header_value": types.StringType,
+	}
+}
+
 type notificationSettingsVictorOps struct {
 	ApiKey     types.String `tfsdk:"api_key" json:"apiKey"`
 	RoutingKey types.String `tfsdk:"routing_key" json:"routingKey"`
@@ -141,6 +212,13 @@ type notificationSettingsVictorOps struct {
 type clientVictorOps struct {
 	ApiKey     string `tfsdk:"api_key" json:"apiKey"`
 	RoutingKey string `tfsdk:"routing_key" json:"routingKey"`
+}
+
+func VictorOpsAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"api_key":     types.StringType,
+		"routing_key": types.StringType,
+	}
 }
 
 type notificationSettingsAmazonSNS struct {
@@ -155,12 +233,26 @@ type clientAmazonSNS struct {
 	SecretAccessKey string `tfsdk:"secret_access_key" json:"secretAccessKey"`
 }
 
+func AmazonSNSAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"topic_arn":         types.StringType,
+		"access_key_id":     types.StringType,
+		"secret_access_key": types.StringType,
+	}
+}
+
 type notificationSettingsZapier struct {
 	Url types.String `tfsdk:"url" json:"url"`
 }
 
 type clientZapier struct {
 	Url string `tfsdk:"url" json:"url"`
+}
+
+func ZapierAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"url": types.StringType,
+	}
 }
 
 type notificationSettingsPushover struct {
@@ -173,6 +265,13 @@ type clientPushover struct {
 	AppToken string `tfsdk:"app_token" json:"appToken"`
 }
 
+func PushoverAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"user_key":  types.StringType,
+		"app_token": types.StringType,
+	}
+}
+
 type notificationSettingsSolarWindsServiceDesk struct {
 	AppToken types.String `tfsdk:"app_token" json:"appToken"`
 	IsEU     types.Bool   `tfsdk:"is_eu" json:"isEu"`
@@ -181,6 +280,13 @@ type notificationSettingsSolarWindsServiceDesk struct {
 type clientSolarWindsServiceDesk struct {
 	AppToken string `tfsdk:"app_token" json:"appToken"`
 	IsEU     bool   `tfsdk:"is_eu" json:"isEu"`
+}
+
+func SolarWindsServiceDeskAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"app_token": types.StringType,
+		"is_eu":     types.BoolType,
+	}
 }
 
 type notificationSettingsServiceNow struct {
@@ -193,9 +299,16 @@ type clientServiceNow struct {
 	Instance string `tfsdk:"instance" json:"instance"`
 }
 
+func ServiceNowAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"app_token": types.StringType,
+		"instance":  types.StringType,
+	}
+}
+
 type notificationSettingsAccessor struct {
 	Get func(m *notificationSettings, ctx context.Context) any
-	Set func(m *notificationResourceModel, settings any) error
+	Set func(m *notificationSettings, settings any, ctx context.Context) error
 }
 
 var settingsAccessors = map[string]notificationSettingsAccessor{
@@ -213,17 +326,37 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 					Email: h.Email.ValueString(),
 				}
 			})
-			var e = clientEmail{
-				Addresses: c,
+			o := clientEmail{Addresses: c}
+			return o
+		},
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			d, err := toSettingsStruct[clientEmail](settings)
+
+			var elements []attr.Value
+			for _, a := range d.Addresses {
+				objectValue, _ := types.ObjectValueFrom(
+					ctx,
+					EmailAddressAttributeTypes(),
+					notificationSettingsEmailAddress{
+						Id:    types.StringPointerValue(a.Id),
+						Email: types.StringValue(a.Email),
+					},
+				)
+				elements = append(elements, objectValue)
 			}
 
-			return e
-		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsEmail](settings)
-
-			//tfTcpOptions, d := types.ObjectValueFrom(ctx, UriTcpOptionsAttributeTypes(), tcpElement)
-			//m.Settings.Email = s
+			setValue, d2 := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: EmailAddressAttributeTypes()}, elements)
+			if d2.HasError() {
+				return nil
+			}
+			var email notificationSettingsEmail
+			m.Email.As(ctx, &email, basetypes.ObjectAsOptions{})
+			email.Addresses = setValue
+			o, d3 := types.ObjectValueFrom(ctx, EmailAttributeTypes(), email)
+			if d3.HasError() {
+				return nil
+			}
+			m.Email = o
 			return err
 		},
 	},
@@ -236,9 +369,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsSlack](settings)
-			//m.Settings.Slack = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientSlack](settings)
+			o, _ := types.ObjectValueFrom(ctx, SlackAttributeTypes(), s)
+			m.Slack = o
 			return err
 		},
 	},
@@ -253,9 +387,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsPagerDuty](settings)
-			//m.Settings.PagerDuty = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientPagerDuty](settings)
+			o, _ := types.ObjectValueFrom(ctx, PagerDutyAttributeTypes(), s)
+			m.PagerDuty = o
 			return err
 		},
 	},
@@ -274,9 +409,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsWebhook](settings)
-			//m.Settings.Webhook = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientWebhook](settings)
+			o, _ := types.ObjectValueFrom(ctx, WebhookAttributeTypes(), s)
+			m.Webhook = o
 			return err
 		},
 	},
@@ -290,9 +426,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsVictorOps](settings)
-			//m.Settings.VictorOps = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientVictorOps](settings)
+			o, _ := types.ObjectValueFrom(ctx, VictorOpsAttributeTypes(), s)
+			m.VictorOps = o
 			return err
 		},
 	},
@@ -309,10 +446,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsOpsGenie](settings)
-
-			//m.Settings.OpsGenie = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientOpsGenie](settings)
+			o, _ := types.ObjectValueFrom(ctx, OpsGenieAttributeTypes(), s)
+			m.OpsGenie = o
 			return err
 		},
 	},
@@ -327,9 +464,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsAmazonSNS](settings)
-			//m.Settings.AmazonSNS = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientAmazonSNS](settings)
+			o, _ := types.ObjectValueFrom(ctx, AmazonSNSAttributeTypes(), s)
+			m.AmazonSNS = o
 			return err
 		},
 	},
@@ -342,9 +480,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsZapier](settings)
-			//m.Settings.Zapier = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientZapier](settings)
+			o, _ := types.ObjectValueFrom(ctx, ZapierAttributeTypes(), s)
+			m.Zapier = o
 			return err
 		},
 	},
@@ -357,9 +496,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsMsTeams](settings)
-			//m.Settings.MsTeams = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientMsTeams](settings)
+			o, _ := types.ObjectValueFrom(ctx, MsTeamsAttributeTypes(), s)
+			m.MsTeams = o
 			return err
 		},
 	},
@@ -373,9 +513,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsPushover](settings)
-			//m.Settings.Pushover = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientPushover](settings)
+			o, _ := types.ObjectValueFrom(ctx, PushoverAttributeTypes(), s)
+			m.Pushover = o
 			return err
 		},
 	},
@@ -388,9 +529,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsSms](settings)
-			//m.Settings.Sms = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientSms](settings)
+			o, _ := types.ObjectValueFrom(ctx, SmsAttributeTypes(), s)
+			m.Sms = o
 			return err
 		},
 	},
@@ -404,9 +546,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsSolarWindsServiceDesk](settings)
-			//m.Settings.SolarWindsServiceDesk = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientSolarWindsServiceDesk](settings)
+			o, _ := types.ObjectValueFrom(ctx, SolarWindsServiceDeskAttributeTypes(), s)
+			m.SolarWindsServiceDesk = o
 			return err
 		},
 	},
@@ -420,9 +563,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			}
 			return c
 		},
-		Set: func(m *notificationResourceModel, settings any) error {
-			_, err := toSettingsStruct[notificationSettingsServiceNow](settings)
-			//m.Settings.ServiceNow = s
+		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
+			s, err := toSettingsStruct[clientServiceNow](settings)
+			o, _ := types.ObjectValueFrom(ctx, ServiceNowAttributeTypes(), s)
+			m.ServiceNow = o
 			return err
 		},
 	},
@@ -444,16 +588,37 @@ func toSettingsStruct[T any](settings any) (*T, error) {
 	return &concreteSettings, nil
 }
 
-func (m *notificationResourceModel) SetSettings(settings any) error {
+func (m *notificationResourceModel) SetSettings(settings *any, ctx context.Context) error {
 
 	if accessor, found := settingsAccessors[m.Type.ValueString()]; found {
 		if m.Settings.IsNull() {
 			m.Settings = types.ObjectNull(NotificationSettingsAttributeTypes())
 		}
-		err := accessor.Set(m, settings)
+
+		var model = notificationSettings{
+			Email:                 types.ObjectNull(EmailAttributeTypes()),
+			Slack:                 types.ObjectNull(SlackAttributeTypes()),
+			PagerDuty:             types.ObjectNull(PagerDutyAttributeTypes()),
+			MsTeams:               types.ObjectNull(MsTeamsAttributeTypes()),
+			Webhook:               types.ObjectNull(WebhookAttributeTypes()),
+			VictorOps:             types.ObjectNull(VictorOpsAttributeTypes()),
+			OpsGenie:              types.ObjectNull(OpsGenieAttributeTypes()),
+			AmazonSNS:             types.ObjectNull(AmazonSNSAttributeTypes()),
+			Zapier:                types.ObjectNull(ZapierAttributeTypes()),
+			Pushover:              types.ObjectNull(PushoverAttributeTypes()),
+			Sms:                   types.ObjectNull(SmsAttributeTypes()),
+			SolarWindsServiceDesk: types.ObjectNull(SolarWindsServiceDeskAttributeTypes()),
+			ServiceNow:            types.ObjectNull(ServiceNowAttributeTypes()),
+		}
+
+		err := accessor.Set(&model, settings, ctx)
 		if err != nil {
 			return err
 		}
+
+		o, _ := types.ObjectValueFrom(ctx, NotificationSettingsAttributeTypes(), model)
+		m.Settings = o
+
 	} else {
 		return newUnsupportedNotificationTypeError(m.Type.ValueString())
 	}

--- a/internal/provider/notificationSettings.go
+++ b/internal/provider/notificationSettings.go
@@ -1,9 +1,13 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"log"
 )
 
@@ -16,31 +20,56 @@ func newUnsupportedNotificationTypeError(notificationType string) error {
 }
 
 type notificationSettings struct {
-	Email                 *notificationSettingsEmail                 `tfsdk:"email"`
-	Slack                 *notificationSettingsSlack                 `tfsdk:"slack"`
-	PagerDuty             *notificationSettingsPagerDuty             `tfsdk:"pagerduty"`
-	MsTeams               *notificationSettingsMsTeams               `tfsdk:"msteams"`
-	Webhook               *notificationSettingsWebhook               `tfsdk:"webhook"`
-	VictorOps             *notificationSettingsVictorOps             `tfsdk:"victorops"`
-	OpsGenie              *notificationSettingsOpsGenie              `tfsdk:"opsgenie"`
-	AmazonSNS             *notificationSettingsAmazonSNS             `tfsdk:"amazonsns"`
-	Zapier                *notificationSettingsZapier                `tfsdk:"zapier"`
-	Pushover              *notificationSettingsPushover              `tfsdk:"pushover"`
-	Sms                   *notificationSettingsSms                   `tfsdk:"sms"`
-	SolarWindsServiceDesk *notificationSettingsSolarWindsServiceDesk `tfsdk:"swsd"`
-	ServiceNow            *notificationSettingsServiceNow            `tfsdk:"servicenow"`
+	Email                 types.Object `tfsdk:"email"`
+	Slack                 types.Object `tfsdk:"slack"`
+	PagerDuty             types.Object `tfsdk:"pagerduty"`
+	MsTeams               types.Object `tfsdk:"msteams"`
+	Webhook               types.Object `tfsdk:"webhook"`
+	VictorOps             types.Object `tfsdk:"victorops"`
+	OpsGenie              types.Object `tfsdk:"opsgenie"`
+	AmazonSNS             types.Object `tfsdk:"amazonsns"`
+	Zapier                types.Object `tfsdk:"zapier"`
+	Pushover              types.Object `tfsdk:"pushover"`
+	Sms                   types.Object `tfsdk:"sms"`
+	SolarWindsServiceDesk types.Object `tfsdk:"swsd"`
+	ServiceNow            types.Object `tfsdk:"servicenow"`
+}
+
+func NotificationSettingsAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"port":             types.Int64Type,
+		"string_to_expect": types.StringType,
+		"string_to_send":   types.StringType,
+	}
 }
 
 type notificationSettingsEmail struct {
-	Addresses []notificationSettingsEmailAddress `tfsdk:"addresses" json:"addresses"`
+	Addresses types.Set `tfsdk:"addresses" json:"addresses"`
+}
+
+type clientEmail struct {
+	Addresses []clientEmailAddress `tfsdk:"addresses" json:"addresses"`
 }
 
 type notificationSettingsEmailAddress struct {
+	Id    types.String `tfsdk:"id" json:"id"`
+	Email types.String `tfsdk:"email" json:"email"`
+}
+
+type clientEmailAddress struct {
 	Id    *string `tfsdk:"id" json:"id"`
 	Email string  `tfsdk:"email" json:"email"`
 }
 
 type notificationSettingsOpsGenie struct {
+	HostName   types.String `tfsdk:"hostname" json:"hostname"`
+	ApiKey     types.String `tfsdk:"api_key" json:"apiKey"`
+	Recipients types.String `tfsdk:"recipients" json:"recipients"`
+	Teams      types.String `tfsdk:"teams" json:"teams"`
+	Tags       types.String `tfsdk:"tags" json:"tags"`
+}
+
+type clientOpsGenie struct {
 	HostName   string `tfsdk:"hostname" json:"hostname"`
 	ApiKey     string `tfsdk:"api_key" json:"apiKey"`
 	Recipients string `tfsdk:"recipients" json:"recipients"`
@@ -49,24 +78,52 @@ type notificationSettingsOpsGenie struct {
 }
 
 type notificationSettingsSms struct {
+	PhoneNumbers types.String `tfsdk:"phone_numbers" json:"phoneNumbers"`
+}
+
+type clientSms struct {
 	PhoneNumbers string `tfsdk:"phone_numbers" json:"phoneNumbers"`
 }
 
 type notificationSettingsSlack struct {
+	Url types.String `tfsdk:"url" json:"url"`
+}
+
+type clientSlack struct {
 	Url string `tfsdk:"url" json:"url"`
 }
 
 type notificationSettingsMsTeams struct {
+	Url types.String `tfsdk:"url" json:"url"`
+}
+
+type clientMsTeams struct {
 	Url string `tfsdk:"url" json:"url"`
 }
 
 type notificationSettingsPagerDuty struct {
+	RoutingKey types.String `tfsdk:"routing_key" json:"routingKey"`
+	Summary    types.String `tfsdk:"summary" json:"summary"`
+	DedupKey   types.String `tfsdk:"dedup_key" json:"dedupKey"`
+}
+
+type clientPagerDuty struct {
 	RoutingKey string `tfsdk:"routing_key" json:"routingKey"`
 	Summary    string `tfsdk:"summary" json:"summary"`
 	DedupKey   string `tfsdk:"dedup_key" json:"dedupKey"`
 }
 
 type notificationSettingsWebhook struct {
+	Url             types.String `tfsdk:"url" json:"url"`
+	Method          types.String `tfsdk:"method" json:"method"`
+	AuthType        types.String `tfsdk:"auth_type" json:"authType"`
+	AuthUsername    types.String `tfsdk:"auth_username" json:"authUsername"`
+	AuthPassword    types.String `tfsdk:"auth_password" json:"authPassword"`
+	AuthHeaderName  types.String `tfsdk:"auth_header_name" json:"authHeaderName"`
+	AuthHeaderValue types.String `tfsdk:"auth_header_value" json:"authHeaderValue"`
+}
+
+type clientWebhook struct {
 	Url             string `tfsdk:"url" json:"url"`
 	Method          string `tfsdk:"method" json:"method"`
 	AuthType        string `tfsdk:"auth_type" json:"authType"`
@@ -77,168 +134,295 @@ type notificationSettingsWebhook struct {
 }
 
 type notificationSettingsVictorOps struct {
+	ApiKey     types.String `tfsdk:"api_key" json:"apiKey"`
+	RoutingKey types.String `tfsdk:"routing_key" json:"routingKey"`
+}
+
+type clientVictorOps struct {
 	ApiKey     string `tfsdk:"api_key" json:"apiKey"`
 	RoutingKey string `tfsdk:"routing_key" json:"routingKey"`
 }
 
 type notificationSettingsAmazonSNS struct {
+	TopicARN        types.String `tfsdk:"topic_arn" json:"topicARN"`
+	AccessKeyID     types.String `tfsdk:"access_key_id" json:"accessKeyID"`
+	SecretAccessKey types.String `tfsdk:"secret_access_key" json:"secretAccessKey"`
+}
+
+type clientAmazonSNS struct {
 	TopicARN        string `tfsdk:"topic_arn" json:"topicARN"`
 	AccessKeyID     string `tfsdk:"access_key_id" json:"accessKeyID"`
 	SecretAccessKey string `tfsdk:"secret_access_key" json:"secretAccessKey"`
 }
 
 type notificationSettingsZapier struct {
+	Url types.String `tfsdk:"url" json:"url"`
+}
+
+type clientZapier struct {
 	Url string `tfsdk:"url" json:"url"`
 }
 
 type notificationSettingsPushover struct {
+	UserKey  types.String `tfsdk:"user_key" json:"userKey"`
+	AppToken types.String `tfsdk:"app_token" json:"appToken"`
+}
+
+type clientPushover struct {
 	UserKey  string `tfsdk:"user_key" json:"userKey"`
 	AppToken string `tfsdk:"app_token" json:"appToken"`
 }
 
 type notificationSettingsSolarWindsServiceDesk struct {
+	AppToken types.String `tfsdk:"app_token" json:"appToken"`
+	IsEU     types.Bool   `tfsdk:"is_eu" json:"isEu"`
+}
+
+type clientSolarWindsServiceDesk struct {
 	AppToken string `tfsdk:"app_token" json:"appToken"`
 	IsEU     bool   `tfsdk:"is_eu" json:"isEu"`
 }
 
 type notificationSettingsServiceNow struct {
+	AppToken types.String `tfsdk:"app_token" json:"appToken"`
+	Instance types.String `tfsdk:"instance" json:"instance"`
+}
+
+type clientServiceNow struct {
 	AppToken string `tfsdk:"app_token" json:"appToken"`
 	Instance string `tfsdk:"instance" json:"instance"`
 }
 
 type notificationSettingsAccessor struct {
-	Get func(m *notificationResourceModel) any
+	Get func(m *notificationSettings, ctx context.Context) any
 	Set func(m *notificationResourceModel, settings any) error
 }
 
 var settingsAccessors = map[string]notificationSettingsAccessor{
 	"email": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.Email
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var email notificationSettingsEmail
+			m.Email.As(ctx, &email, basetypes.ObjectAsOptions{})
+			var addresses []notificationSettingsEmailAddress
+			email.Addresses.ElementsAs(ctx, &addresses, false)
+
+			var c []clientEmailAddress
+			c = convertArray(addresses, func(h notificationSettingsEmailAddress) clientEmailAddress {
+				return clientEmailAddress{
+					Id:    h.Id.ValueStringPointer(),
+					Email: h.Email.ValueString(),
+				}
+			})
+			var e = clientEmail{
+				Addresses: c,
+			}
+
+			return e
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsEmail](settings)
-			m.Settings.Email = s
+			_, err := toSettingsStruct[notificationSettingsEmail](settings)
+
+			//tfTcpOptions, d := types.ObjectValueFrom(ctx, UriTcpOptionsAttributeTypes(), tcpElement)
+			//m.Settings.Email = s
 			return err
 		},
 	},
 	"slack": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.Slack
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var slack notificationSettingsSlack
+			m.Slack.As(ctx, &slack, basetypes.ObjectAsOptions{})
+			c := clientSlack{
+				Url: slack.Url.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsSlack](settings)
-			m.Settings.Slack = s
+			_, err := toSettingsStruct[notificationSettingsSlack](settings)
+			//m.Settings.Slack = s
 			return err
 		},
 	},
 	"pagerduty": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.PagerDuty
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var pagerDuty notificationSettingsPagerDuty
+			m.PagerDuty.As(ctx, &pagerDuty, basetypes.ObjectAsOptions{})
+			c := clientPagerDuty{
+				RoutingKey: pagerDuty.RoutingKey.ValueString(),
+				Summary:    pagerDuty.Summary.ValueString(),
+				DedupKey:   pagerDuty.DedupKey.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsPagerDuty](settings)
-			m.Settings.PagerDuty = s
+			_, err := toSettingsStruct[notificationSettingsPagerDuty](settings)
+			//m.Settings.PagerDuty = s
 			return err
 		},
 	},
 	"webhook": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.Webhook
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var webhook notificationSettingsWebhook
+			m.Webhook.As(ctx, &webhook, basetypes.ObjectAsOptions{})
+			c := clientWebhook{
+				Url:             webhook.Url.ValueString(),
+				Method:          webhook.Method.ValueString(),
+				AuthType:        webhook.AuthType.ValueString(),
+				AuthUsername:    webhook.AuthUsername.ValueString(),
+				AuthPassword:    webhook.AuthPassword.ValueString(),
+				AuthHeaderName:  webhook.AuthHeaderName.ValueString(),
+				AuthHeaderValue: webhook.AuthHeaderValue.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsWebhook](settings)
-			m.Settings.Webhook = s
+			_, err := toSettingsStruct[notificationSettingsWebhook](settings)
+			//m.Settings.Webhook = s
 			return err
 		},
 	},
 	"victorops": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.VictorOps
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var victorOps notificationSettingsVictorOps
+			m.VictorOps.As(ctx, &victorOps, basetypes.ObjectAsOptions{})
+			c := clientVictorOps{
+				ApiKey:     victorOps.ApiKey.ValueString(),
+				RoutingKey: victorOps.RoutingKey.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsVictorOps](settings)
-			m.Settings.VictorOps = s
+			_, err := toSettingsStruct[notificationSettingsVictorOps](settings)
+			//m.Settings.VictorOps = s
 			return err
 		},
 	},
 	"opsgenie": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.OpsGenie
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var opsGenie notificationSettingsOpsGenie
+			m.OpsGenie.As(ctx, &opsGenie, basetypes.ObjectAsOptions{})
+			c := clientOpsGenie{
+				HostName:   opsGenie.HostName.ValueString(),
+				ApiKey:     opsGenie.ApiKey.ValueString(),
+				Recipients: opsGenie.Recipients.ValueString(),
+				Teams:      opsGenie.Teams.ValueString(),
+				Tags:       opsGenie.Tags.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsOpsGenie](settings)
-			m.Settings.OpsGenie = s
+			_, err := toSettingsStruct[notificationSettingsOpsGenie](settings)
+
+			//m.Settings.OpsGenie = s
 			return err
 		},
 	},
 	"amazonsns": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.AmazonSNS
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var amazonSns notificationSettingsAmazonSNS
+			m.AmazonSNS.As(ctx, &amazonSns, basetypes.ObjectAsOptions{})
+			c := clientAmazonSNS{
+				TopicARN:        amazonSns.TopicARN.ValueString(),
+				AccessKeyID:     amazonSns.AccessKeyID.ValueString(),
+				SecretAccessKey: amazonSns.SecretAccessKey.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsAmazonSNS](settings)
-			m.Settings.AmazonSNS = s
+			_, err := toSettingsStruct[notificationSettingsAmazonSNS](settings)
+			//m.Settings.AmazonSNS = s
 			return err
 		},
 	},
 	"zapier": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.Zapier
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var zapier notificationSettingsZapier
+			m.Zapier.As(ctx, &zapier, basetypes.ObjectAsOptions{})
+			c := clientZapier{
+				Url: zapier.Url.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsZapier](settings)
-			m.Settings.Zapier = s
+			_, err := toSettingsStruct[notificationSettingsZapier](settings)
+			//m.Settings.Zapier = s
 			return err
 		},
 	},
 	"msTeams": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.MsTeams
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var msTeams notificationSettingsMsTeams
+			m.MsTeams.As(ctx, &msTeams, basetypes.ObjectAsOptions{})
+			c := clientMsTeams{
+				Url: msTeams.Url.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsMsTeams](settings)
-			m.Settings.MsTeams = s
+			_, err := toSettingsStruct[notificationSettingsMsTeams](settings)
+			//m.Settings.MsTeams = s
 			return err
 		},
 	},
 	"pushover": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.Pushover
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var pushover notificationSettingsPushover
+			m.Pushover.As(ctx, &pushover, basetypes.ObjectAsOptions{})
+			c := clientPushover{
+				UserKey:  pushover.UserKey.ValueString(),
+				AppToken: pushover.AppToken.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsPushover](settings)
-			m.Settings.Pushover = s
+			_, err := toSettingsStruct[notificationSettingsPushover](settings)
+			//m.Settings.Pushover = s
 			return err
 		},
 	},
 	"sms": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.Sms
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var sms notificationSettingsSms
+			m.Sms.As(ctx, &sms, basetypes.ObjectAsOptions{})
+			c := clientSms{
+				PhoneNumbers: sms.PhoneNumbers.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsSms](settings)
-			m.Settings.Sms = s
+			_, err := toSettingsStruct[notificationSettingsSms](settings)
+			//m.Settings.Sms = s
 			return err
 		},
 	},
 	"swsd": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.SolarWindsServiceDesk
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var swoServiceDesk notificationSettingsSolarWindsServiceDesk
+			m.SolarWindsServiceDesk.As(ctx, &swoServiceDesk, basetypes.ObjectAsOptions{})
+			c := clientSolarWindsServiceDesk{
+				AppToken: swoServiceDesk.AppToken.ValueString(),
+				IsEU:     swoServiceDesk.IsEU.ValueBool(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsSolarWindsServiceDesk](settings)
-			m.Settings.SolarWindsServiceDesk = s
+			_, err := toSettingsStruct[notificationSettingsSolarWindsServiceDesk](settings)
+			//m.Settings.SolarWindsServiceDesk = s
 			return err
 		},
 	},
 	"servicenow": {
-		Get: func(m *notificationResourceModel) any {
-			return m.Settings.ServiceNow
+		Get: func(m *notificationSettings, ctx context.Context) any {
+			var serviceNow notificationSettingsServiceNow
+			m.ServiceNow.As(ctx, &serviceNow, basetypes.ObjectAsOptions{})
+			c := clientServiceNow{
+				AppToken: serviceNow.AppToken.ValueString(),
+				Instance: serviceNow.Instance.ValueString(),
+			}
+			return c
 		},
 		Set: func(m *notificationResourceModel, settings any) error {
-			s, err := toSettingsStruct[notificationSettingsServiceNow](settings)
-			m.Settings.ServiceNow = s
+			_, err := toSettingsStruct[notificationSettingsServiceNow](settings)
+			//m.Settings.ServiceNow = s
 			return err
 		},
 	},
@@ -261,9 +445,10 @@ func toSettingsStruct[T any](settings any) (*T, error) {
 }
 
 func (m *notificationResourceModel) SetSettings(settings any) error {
+
 	if accessor, found := settingsAccessors[m.Type.ValueString()]; found {
-		if m.Settings == nil {
-			m.Settings = &notificationSettings{}
+		if m.Settings.IsNull() {
+			m.Settings = types.ObjectNull(NotificationSettingsAttributeTypes())
 		}
 		err := accessor.Set(m, settings)
 		if err != nil {
@@ -276,12 +461,17 @@ func (m *notificationResourceModel) SetSettings(settings any) error {
 	return nil
 }
 
-func (m *notificationResourceModel) GetSettings() any {
+func (m *notificationResourceModel) GetSettings(ctx context.Context) any {
+
 	if accessor, found := settingsAccessors[m.Type.ValueString()]; found {
-		if m.Settings == nil {
-			m.Settings = &notificationSettings{}
+		if m.Settings.IsNull() {
+			m.Settings = types.ObjectNull(NotificationSettingsAttributeTypes())
+			return nil
 		}
-		return accessor.Get(m)
+
+		var settings notificationSettings
+		m.Settings.As(ctx, &settings, basetypes.ObjectAsOptions{})
+		return accessor.Get(&settings, ctx)
 	}
 
 	log.Printf("unsupported notification type. got %s", m.Type.ValueString())

--- a/internal/provider/notificationSettings.go
+++ b/internal/provider/notificationSettings.go
@@ -25,12 +25,10 @@ type notificationSettings struct {
 	PagerDuty             types.Object `tfsdk:"pagerduty"`
 	MsTeams               types.Object `tfsdk:"msteams"`
 	Webhook               types.Object `tfsdk:"webhook"`
-	VictorOps             types.Object `tfsdk:"victorops"`
 	OpsGenie              types.Object `tfsdk:"opsgenie"`
 	AmazonSNS             types.Object `tfsdk:"amazonsns"`
 	Zapier                types.Object `tfsdk:"zapier"`
 	Pushover              types.Object `tfsdk:"pushover"`
-	Sms                   types.Object `tfsdk:"sms"`
 	SolarWindsServiceDesk types.Object `tfsdk:"swsd"`
 	ServiceNow            types.Object `tfsdk:"servicenow"`
 }
@@ -42,12 +40,10 @@ func NotificationSettingsAttributeTypes() map[string]attr.Type {
 		"pagerduty":  types.ObjectType{AttrTypes: PagerDutyAttributeTypes()},
 		"msteams":    types.ObjectType{AttrTypes: MsTeamsAttributeTypes()},
 		"webhook":    types.ObjectType{AttrTypes: WebhookAttributeTypes()},
-		"victorops":  types.ObjectType{AttrTypes: VictorOpsAttributeTypes()},
 		"opsgenie":   types.ObjectType{AttrTypes: OpsGenieAttributeTypes()},
 		"amazonsns":  types.ObjectType{AttrTypes: AmazonSNSAttributeTypes()},
 		"zapier":     types.ObjectType{AttrTypes: ZapierAttributeTypes()},
 		"pushover":   types.ObjectType{AttrTypes: PushoverAttributeTypes()},
-		"sms":        types.ObjectType{AttrTypes: SmsAttributeTypes()},
 		"swsd":       types.ObjectType{AttrTypes: SolarWindsServiceDeskAttributeTypes()},
 		"servicenow": types.ObjectType{AttrTypes: ServiceNowAttributeTypes()},
 	}
@@ -107,20 +103,6 @@ func OpsGenieAttributeTypes() map[string]attr.Type {
 		"recipients": types.StringType,
 		"teams":      types.StringType,
 		"tags":       types.StringType,
-	}
-}
-
-type notificationSettingsSms struct {
-	PhoneNumbers types.String `tfsdk:"phone_numbers" json:"phoneNumbers"`
-}
-
-type clientSms struct {
-	PhoneNumbers string `tfsdk:"phone_numbers" json:"phoneNumbers"`
-}
-
-func SmsAttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"phone_numbers": types.StringType,
 	}
 }
 
@@ -201,23 +183,6 @@ func WebhookAttributeTypes() map[string]attr.Type {
 		"auth_password":     types.StringType,
 		"auth_header_name":  types.StringType,
 		"auth_header_value": types.StringType,
-	}
-}
-
-type notificationSettingsVictorOps struct {
-	ApiKey     types.String `tfsdk:"api_key" json:"apiKey"`
-	RoutingKey types.String `tfsdk:"routing_key" json:"routingKey"`
-}
-
-type clientVictorOps struct {
-	ApiKey     string `tfsdk:"api_key" json:"apiKey"`
-	RoutingKey string `tfsdk:"routing_key" json:"routingKey"`
-}
-
-func VictorOpsAttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"api_key":     types.StringType,
-		"routing_key": types.StringType,
 	}
 }
 
@@ -414,22 +379,6 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			return err
 		},
 	},
-	"victorops": {
-		Get: func(m *notificationSettings, ctx context.Context) any {
-			var victorOps notificationSettingsVictorOps
-			m.VictorOps.As(ctx, &victorOps, basetypes.ObjectAsOptions{})
-			return clientVictorOps{
-				ApiKey:     victorOps.ApiKey.ValueString(),
-				RoutingKey: victorOps.RoutingKey.ValueString(),
-			}
-		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
-			s, err := toSettingsStruct[clientVictorOps](settings)
-			o, _ := types.ObjectValueFrom(ctx, VictorOpsAttributeTypes(), s)
-			m.VictorOps = o
-			return err
-		},
-	},
 	"opsgenie": {
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var opsGenie notificationSettingsOpsGenie
@@ -512,21 +461,6 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 			return err
 		},
 	},
-	"sms": {
-		Get: func(m *notificationSettings, ctx context.Context) any {
-			var sms notificationSettingsSms
-			m.Sms.As(ctx, &sms, basetypes.ObjectAsOptions{})
-			return clientSms{
-				PhoneNumbers: sms.PhoneNumbers.ValueString(),
-			}
-		},
-		Set: func(m *notificationSettings, settings any, ctx context.Context) error {
-			s, err := toSettingsStruct[clientSms](settings)
-			o, _ := types.ObjectValueFrom(ctx, SmsAttributeTypes(), s)
-			m.Sms = o
-			return err
-		},
-	},
 	"swsd": {
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var swoServiceDesk notificationSettingsSolarWindsServiceDesk
@@ -590,12 +524,10 @@ func (m *notificationResourceModel) SetSettings(settings *any, ctx context.Conte
 			PagerDuty:             types.ObjectNull(PagerDutyAttributeTypes()),
 			MsTeams:               types.ObjectNull(MsTeamsAttributeTypes()),
 			Webhook:               types.ObjectNull(WebhookAttributeTypes()),
-			VictorOps:             types.ObjectNull(VictorOpsAttributeTypes()),
 			OpsGenie:              types.ObjectNull(OpsGenieAttributeTypes()),
 			AmazonSNS:             types.ObjectNull(AmazonSNSAttributeTypes()),
 			Zapier:                types.ObjectNull(ZapierAttributeTypes()),
 			Pushover:              types.ObjectNull(PushoverAttributeTypes()),
-			Sms:                   types.ObjectNull(SmsAttributeTypes()),
 			SolarWindsServiceDesk: types.ObjectNull(SolarWindsServiceDeskAttributeTypes()),
 			ServiceNow:            types.ObjectNull(ServiceNowAttributeTypes()),
 		}

--- a/internal/provider/notificationSettings.go
+++ b/internal/provider/notificationSettings.go
@@ -344,7 +344,10 @@ var settingsAccessors = map[string]notificationSettingsAccessor{
 	"pagerduty": {
 		Get: func(m *notificationSettings, ctx context.Context) any {
 			var pagerDuty notificationSettingsPagerDuty
-			m.PagerDuty.As(ctx, &pagerDuty, basetypes.ObjectAsOptions{})
+			d := m.PagerDuty.As(ctx, &pagerDuty, basetypes.ObjectAsOptions{})
+			if d.HasError() {
+				return nil
+			}
 			return clientPagerDuty{
 				RoutingKey: pagerDuty.RoutingKey.ValueString(),
 				Summary:    pagerDuty.Summary.ValueString(),

--- a/internal/provider/notification_resource.go
+++ b/internal/provider/notification_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -92,13 +91,11 @@ func (r *notificationResource) Read(ctx context.Context, req resource.ReadReques
 	tfState.Title = types.StringValue(notification.Title)
 	tfState.Type = types.StringValue(notification.Type)
 	tfState.Description = types.StringPointerValue(notification.Description)
-
-	err = tfState.SetSettings(notification.Settings)
+	err = tfState.SetSettings(notification.Settings, ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Settings Error", err.Error())
 		return
 	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, tfState)...)
 }
 

--- a/internal/provider/notification_resource.go
+++ b/internal/provider/notification_resource.go
@@ -43,13 +43,13 @@ func (r *notificationResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Create the notification...
-	newNotification, err := r.client.NotificationsService().Create(ctx,
-		swoClient.CreateNotificationInput{
-			Title:       tfPlan.Title.ValueString(),
-			Description: tfPlan.Description.ValueStringPointer(),
-			Type:        tfPlan.Type.ValueString(),
-			Settings:    tfPlan.GetSettings(),
-		})
+	input := swoClient.CreateNotificationInput{
+		Title:       tfPlan.Title.ValueString(),
+		Description: tfPlan.Description.ValueStringPointer(),
+		Type:        tfPlan.Type.ValueString(),
+		Settings:    tfPlan.GetSettings(ctx),
+	}
+	newNotification, err := r.client.NotificationsService().Create(ctx, input)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
@@ -117,7 +117,7 @@ func (r *notificationResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	settings := tfPlan.GetSettings()
+	settings := tfPlan.GetSettings(ctx)
 
 	// Update the notification...
 	_, err = r.client.NotificationsService().Update(ctx,

--- a/internal/provider/notification_resource.go
+++ b/internal/provider/notification_resource.go
@@ -84,7 +84,6 @@ func (r *notificationResource) Read(ctx context.Context, req resource.ReadReques
 
 	// Read the notification...
 	notification, err := r.client.NotificationsService().Read(ctx, nId, nType)
-
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("error reading notification %s. error: %s", nId, err))
@@ -95,11 +94,7 @@ func (r *notificationResource) Read(ctx context.Context, req resource.ReadReques
 	tfState.Title = types.StringValue(notification.Title)
 	tfState.Type = types.StringValue(notification.Type)
 	tfState.Description = types.StringPointerValue(notification.Description)
-	err = tfState.SetSettings(notification.Settings, ctx, &resp.Diagnostics)
-	if err != nil {
-		resp.Diagnostics.AddError("Settings Error", err.Error())
-		return
-	}
+	tfState.SetSettings(notification.Settings, ctx, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/notification_resource.go
+++ b/internal/provider/notification_resource.go
@@ -42,11 +42,15 @@ func (r *notificationResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Create the notification...
+	tfSettings := tfPlan.GetSettings(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	input := swoClient.CreateNotificationInput{
 		Title:       tfPlan.Title.ValueString(),
 		Description: tfPlan.Description.ValueStringPointer(),
 		Type:        tfPlan.Type.ValueString(),
-		Settings:    tfPlan.GetSettings(ctx),
+		Settings:    tfSettings,
 	}
 	newNotification, err := r.client.NotificationsService().Create(ctx, input)
 
@@ -114,15 +118,17 @@ func (r *notificationResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	settings := tfPlan.GetSettings(ctx)
-
+	tfSettings := tfPlan.GetSettings(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	// Update the notification...
 	_, err = r.client.NotificationsService().Update(ctx,
 		swoClient.UpdateNotificationInput{
 			Id:          nId,
 			Title:       tfPlan.Title.ValueStringPointer(),
 			Description: tfPlan.Description.ValueStringPointer(),
-			Settings:    &settings,
+			Settings:    &tfSettings,
 		})
 
 	if err != nil {

--- a/internal/provider/notification_resource.go
+++ b/internal/provider/notification_resource.go
@@ -95,9 +95,12 @@ func (r *notificationResource) Read(ctx context.Context, req resource.ReadReques
 	tfState.Title = types.StringValue(notification.Title)
 	tfState.Type = types.StringValue(notification.Type)
 	tfState.Description = types.StringPointerValue(notification.Description)
-	err = tfState.SetSettings(notification.Settings, ctx)
+	err = tfState.SetSettings(notification.Settings, ctx, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddError("Settings Error", err.Error())
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, tfState)...)

--- a/internal/provider/notification_resource_test.go
+++ b/internal/provider/notification_resource_test.go
@@ -17,17 +17,17 @@ func TestAccEmailResource(t *testing.T) {
 			{
 				Config: testAccEmailConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("swo_notification.test", "id"),
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test one"),
-					resource.TestCheckResourceAttr("swo_notification.test", "description", "testing..."),
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "email"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.email.addresses.0.email", "test1@host.com"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.email.addresses.1.email", "test2@host.com"),
+					resource.TestCheckResourceAttrSet("swo_notification.test_email", "id"),
+					resource.TestCheckResourceAttr("swo_notification.test_email", "title", "test-acc test one"),
+					resource.TestCheckResourceAttr("swo_notification.test_email", "description", "testing..."),
+					resource.TestCheckResourceAttr("swo_notification.test_email", "type", "email"),
+					resource.TestCheckResourceAttr("swo_notification.test_email", "settings.email.addresses.0.email", "test1@host.com"),
+					resource.TestCheckResourceAttr("swo_notification.test_email", "settings.email.addresses.1.email", "test2@host.com"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_email",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -35,17 +35,16 @@ func TestAccEmailResource(t *testing.T) {
 			{
 				Config: testAccEmailConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_email", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})
 }
-
 func testAccEmailConfig(title string) string {
 	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test" {
+	resource "swo_notification" "test_email" {
 		title        = %[1]q
 		description = "testing..."
 		type = "email"
@@ -74,23 +73,24 @@ func TestAccAmazonSnsNotificationResource(t *testing.T) {
 			{
 				Config: testAccAmazonSnsConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "amazonsns"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsns.access_key_id", "KEY_ID"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsns.secret_access_key", "SECRET_KEY"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsns.topic_arn", "arn:aws:sns:us-east-1:123456789012:topic"),
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "type", "amazonsns"),
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "settings.amazonsns.access_key_id", "KEY_ID"),
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "settings.amazonsns.secret_access_key", "SECRET_KEY"),
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "settings.amazonsns.topic_arn", "arn:aws:sns:us-east-1:123456789012:topic"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "swo_notification.test_amazonsns",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"access_key_id", "secret_access_key"},
 			},
 			// Update and Read testing
 			{
 				Config: testAccAmazonSnsConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -99,7 +99,7 @@ func TestAccAmazonSnsNotificationResource(t *testing.T) {
 }
 func testAccAmazonSnsConfig(title string) string {
 	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test_amazon_sns" {
+	resource "swo_notification" "test_amazonsns" {
   		title       = %[1]q
   		description = "testing..."
   		type        = "amazonsns"
@@ -123,13 +123,13 @@ func TestAccMsTeamsNotificationResource(t *testing.T) {
 			{
 				Config: testAccMsTeamsConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "msTeams"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.msteams.url", "https://www.office.com/webhook"),
+					resource.TestCheckResourceAttr("swo_notification.test_msteams", "type", "msTeams"),
+					resource.TestCheckResourceAttr("swo_notification.test_msteams", "settings.msteams.url", "https://solarwinds.webhook.office.com/webhookb2/d31597c"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_msteams",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -137,7 +137,7 @@ func TestAccMsTeamsNotificationResource(t *testing.T) {
 			{
 				Config: testAccMsTeamsConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_msteams", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -168,17 +168,17 @@ func TestAccOpsGenieNotificationResource(t *testing.T) {
 			{
 				Config: testAccOpsGenieConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "opsgenie"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.hostname", "hostname"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.apikey", "API_KEY"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.recipients", "alice"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.teams", "team1, team2"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.tags", "tag1, tag2"),
+					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "type", "opsgenie"),
+					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.hostname", "hostname"),
+					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.api_key", "API_KEY"),
+					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.recipients", "alice"),
+					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.teams", "team1, team2"),
+					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.tags", "tag1, tag2"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_opsgenie",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -186,7 +186,7 @@ func TestAccOpsGenieNotificationResource(t *testing.T) {
 			{
 				Config: testAccOpsGenieConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -221,13 +221,13 @@ func TestAccSlackNotificationResource(t *testing.T) {
 			{
 				Config: testAccSlackConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "slack"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.slack.url", "https://hooks.slack.com/services/XXX/XXX/XXX"),
+					resource.TestCheckResourceAttr("swo_notification.test_slack", "type", "slack"),
+					resource.TestCheckResourceAttr("swo_notification.test_slack", "settings.slack.url", "https://hooks.slack.com/services/XXX/XXX/XXX"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_slack",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -235,7 +235,7 @@ func TestAccSlackNotificationResource(t *testing.T) {
 			{
 				Config: testAccSlackConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_slack", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -266,15 +266,15 @@ func TestAccPagerDutyNotificationResource(t *testing.T) {
 			{
 				Config: testAccPagerdutyConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "pagerduty"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.pagerduty.routing_key", "99999999999999999999999999999999"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.pagerduty.summary", "some-summary"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.pagerduty.dedup_key", "DEDUP"),
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "type", "pagerduty"),
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "settings.pagerduty.routing_key", "99999999999999999999999999999999"),
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "settings.pagerduty.summary", "some-summary"),
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "settings.pagerduty.dedup_key", "DEDUP"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_pagerduty",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -282,7 +282,7 @@ func TestAccPagerDutyNotificationResource(t *testing.T) {
 			{
 				Config: testAccPagerdutyConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -296,9 +296,11 @@ func testAccPagerdutyConfig(title string) string {
   		description = "testing..."
   		type        = "pagerduty"
   		settings = {
-    		routing_key = "99999999999999999999999999999999"
-      		summary     = "some-summary"
-      		dedup_key   = "DEDUP"
+			pagerduty = {
+				routing_key = "99999999999999999999999999999999"
+      			summary     = "some-summary"
+      			dedup_key   = "DEDUP"
+			}
 		}
 	}`, title)
 }
@@ -313,14 +315,14 @@ func TestAccServiceNowNotificationResource(t *testing.T) {
 			{
 				Config: testAccServicenowConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "servicenow"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.servicenow.app_token", "API_TOKEN"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.servicenow.instance", "US"),
+					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "type", "servicenow"),
+					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "settings.servicenow.app_token", "API_TOKEN"),
+					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "settings.servicenow.instance", "US"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_servicenow",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -328,7 +330,7 @@ func TestAccServiceNowNotificationResource(t *testing.T) {
 			{
 				Config: testAccServicenowConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -360,14 +362,14 @@ func TestAccSwsdNotificationResource(t *testing.T) {
 			{
 				Config: testAccSwsdConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "swsd"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.swsd.app_token", "APP_TOKEN"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.swsd.is_eu", "false"),
+					resource.TestCheckResourceAttr("swo_notification.test_swsd", "type", "swsd"),
+					resource.TestCheckResourceAttr("swo_notification.test_swsd", "settings.swsd.app_token", "APP_TOKEN"),
+					resource.TestCheckResourceAttr("swo_notification.test_swsd", "settings.swsd.is_eu", "false"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_swsd",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -375,7 +377,7 @@ func TestAccSwsdNotificationResource(t *testing.T) {
 			{
 				Config: testAccSwsdConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_swsd", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -407,14 +409,14 @@ func TestAccPushoverNotificationResource(t *testing.T) {
 			{
 				Config: testAccPushoverConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "pushover"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.pushover.app_token", "APP_TOKEN"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.pushover.user_key", "123xyz"),
+					resource.TestCheckResourceAttr("swo_notification.test_pushover", "type", "pushover"),
+					resource.TestCheckResourceAttr("swo_notification.test_pushover", "settings.pushover.app_token", "APP_TOKEN"),
+					resource.TestCheckResourceAttr("swo_notification.test_pushover", "settings.pushover.user_key", "123xyz"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_pushover",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -422,7 +424,7 @@ func TestAccPushoverNotificationResource(t *testing.T) {
 			{
 				Config: testAccPushoverConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_pushover", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -454,19 +456,19 @@ func TestAccWebhookNotificationResource(t *testing.T) {
 			{
 				Config: testAccWebhookConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "webhook"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.method", "GET"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.url", "https://webhook.example.com/"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_header_name", "X-Slack-Request-Id"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_header_value", "VALUE"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_password", "PASSWORD"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_type", "basic"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_username", "USERNAME"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "type", "webhook"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.method", "GET"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.url", "https://webhook.example.com/"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_header_name", "X-Slack-Request-Id"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_header_value", "VALUE"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_password", "PASSWORD"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_type", "basic"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_username", "USERNAME"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_webhook",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -474,7 +476,7 @@ func TestAccWebhookNotificationResource(t *testing.T) {
 			{
 				Config: testAccWebhookConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -511,13 +513,13 @@ func TestAccZapierNotificationResource(t *testing.T) {
 			{
 				Config: testAccZapierConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "zapier"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.zapier.url", "https://www.office.com/webhook"),
+					resource.TestCheckResourceAttr("swo_notification.test_zapier", "type", "zapier"),
+					resource.TestCheckResourceAttr("swo_notification.test_zapier", "settings.zapier.url", "https://hooks.zapier.com/hooks/catch/123567/abcdef/"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test",
+				ResourceName:      "swo_notification.test_zapier",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -525,7 +527,7 @@ func TestAccZapierNotificationResource(t *testing.T) {
 			{
 				Config: testAccZapierConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+					resource.TestCheckResourceAttr("swo_notification.test_zapier", "title", "test-acc test two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/notification_resource_test.go
+++ b/internal/provider/notification_resource_test.go
@@ -7,6 +7,56 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func TestAccAmazonSnsNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccAmazonSnsConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "type", "amazonsns"),
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "settings.amazonsns.access_key_id", "KEY_ID"),
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "settings.amazonsns.secret_access_key", "SECRET_KEY"),
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "settings.amazonsns.topic_arn", "arn:aws:sns:us-east-1:123456789012:topic"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "swo_notification.test_amazonsns",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"settings.amazonsns.secret_access_key"},
+			},
+			// Update and Read testing
+			{
+				Config: testAccAmazonSnsConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccAmazonSnsConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_amazonsns" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "amazonsns"
+  		settings = {
+    		amazonsns = {
+				topic_arn = "arn:aws:sns:us-east-1:123456789012:topic"
+				access_key_id = "KEY_ID"
+				secret_access_key = "SECRET_KEY"
+			}
+		}
+	}`, title)
+}
+
 func TestAccEmailResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -63,55 +113,6 @@ func testAccEmailConfig(title string) string {
 	}`, title)
 }
 
-func TestAccAmazonSnsNotificationResource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		IsUnitTest:               true,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: testAccAmazonSnsConfig("test-acc test one"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "type", "amazonsns"),
-					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "settings.amazonsns.access_key_id", "KEY_ID"),
-					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "settings.amazonsns.secret_access_key", "SECRET_KEY"),
-					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "settings.amazonsns.topic_arn", "arn:aws:sns:us-east-1:123456789012:topic"),
-				),
-			},
-			// ImportState testing
-			{
-				ResourceName:      "swo_notification.test_amazonsns",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and Read testing
-			{
-				Config: testAccAmazonSnsConfig("test-acc test two"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test_amazonsns", "title", "test-acc test two"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-func testAccAmazonSnsConfig(title string) string {
-	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test_amazonsns" {
-  		title       = %[1]q
-  		description = "testing..."
-  		type        = "amazonsns"
-  		settings = {
-    		amazonsns = {
-				topic_arn = "arn:aws:sns:us-east-1:123456789012:topic"
-				access_key_id = "KEY_ID"
-				secret_access_key = "SECRET_KEY"
-			}
-		}
-	}`, title)
-}
-
 func TestAccMsTeamsNotificationResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -123,7 +124,7 @@ func TestAccMsTeamsNotificationResource(t *testing.T) {
 				Config: testAccMsTeamsConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("swo_notification.test_msteams", "type", "msTeams"),
-					resource.TestCheckResourceAttr("swo_notification.test_msteams", "settings.msteams.url", "https://solarwinds.webhook.office.com/webhookb2/d31597c"),
+					resource.TestCheckResourceAttr("swo_notification.test_msteams", "settings.msteams.url", "https://XXX.webhook.office.com/webhookb2/XXXXX"),
 				),
 			},
 			// ImportState testing
@@ -151,7 +152,7 @@ func testAccMsTeamsConfig(title string) string {
   		type        = "msTeams"
   		settings = {
     		msteams = {
-      			url = "https://solarwinds.webhook.office.com/webhookb2/d31597c"
+      			url = "https://XXX.webhook.office.com/webhookb2/XXXXX"
 			}
 		}
 	}`, title)
@@ -177,9 +178,10 @@ func TestAccOpsGenieNotificationResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test_opsgenie",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "swo_notification.test_opsgenie",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"settings.opsgenie.api_key"},
 			},
 			// Update and Read testing
 			{
@@ -206,6 +208,152 @@ func testAccOpsGenieConfig(title string) string {
       			teams      = "team1, team2"
       			tags       = "tag1, tag2"
 			}
+		}
+	}`, title)
+}
+
+func TestAccPagerDutyNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccPagerdutyConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "type", "pagerduty"),
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "settings.pagerduty.routing_key", "99999999999999999999999999999999"),
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "settings.pagerduty.summary", "some-summary"),
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "settings.pagerduty.dedup_key", "DEDUP_KEY"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "swo_notification.test_pagerduty",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"settings.pagerduty.routing_key"},
+			},
+			// Update and Read testing
+			{
+				Config: testAccPagerdutyConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccPagerdutyConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_pagerduty" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "pagerduty"
+  		settings = {
+			pagerduty = {
+				routing_key = "99999999999999999999999999999999"
+      			summary     = "some-summary"
+      			dedup_key   = "DEDUP_KEY"
+			}
+		}
+	}`, title)
+}
+
+func TestAccPushoverNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccPushoverConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test_pushover", "type", "pushover"),
+					resource.TestCheckResourceAttr("swo_notification.test_pushover", "settings.pushover.app_token", "APP_TOKEN"),
+					resource.TestCheckResourceAttr("swo_notification.test_pushover", "settings.pushover.user_key", "123xyz"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "swo_notification.test_pushover",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"settings.pushover.app_token"},
+			},
+			// Update and Read testing
+			{
+				Config: testAccPushoverConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test_pushover", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccPushoverConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_pushover" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "pushover"
+  		settings = {
+    		pushover = {
+      			app_token = "APP_TOKEN"
+				user_key  = "123xyz"
+			}
+		}
+	}`, title)
+}
+
+func TestAccServiceNowNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccServicenowConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "type", "servicenow"),
+					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "settings.servicenow.app_token", "APP_TOKEN"),
+					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "settings.servicenow.instance", "US"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "swo_notification.test_servicenow",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"settings.servicenow.app_token"},
+			},
+			// Update and Read testing
+			{
+				Config: testAccServicenowConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccServicenowConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_servicenow" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "servicenow"
+  		settings = {
+    		servicenow = {
+      			app_token = "APP_TOKEN"
+      			instance  = "US"
+    		}
 		}
 	}`, title)
 }
@@ -255,102 +403,6 @@ func testAccSlackConfig(title string) string {
 	}`, title)
 }
 
-func TestAccPagerDutyNotificationResource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		IsUnitTest:               true,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: testAccPagerdutyConfig("test-acc test one"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "type", "pagerduty"),
-					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "settings.pagerduty.routing_key", "99999999999999999999999999999999"),
-					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "settings.pagerduty.summary", "some-summary"),
-					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "settings.pagerduty.dedup_key", "DEDUP"),
-				),
-			},
-			// ImportState testing
-			{
-				ResourceName:      "swo_notification.test_pagerduty",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and Read testing
-			{
-				Config: testAccPagerdutyConfig("test-acc test two"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test_pagerduty", "title", "test-acc test two"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-func testAccPagerdutyConfig(title string) string {
-	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test_pagerduty" {
-  		title       = %[1]q
-  		description = "testing..."
-  		type        = "pagerduty"
-  		settings = {
-			pagerduty = {
-				routing_key = "99999999999999999999999999999999"
-      			summary     = "some-summary"
-      			dedup_key   = "DEDUP"
-			}
-		}
-	}`, title)
-}
-
-func TestAccServiceNowNotificationResource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		IsUnitTest:               true,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: testAccServicenowConfig("test-acc test one"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "type", "servicenow"),
-					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "settings.servicenow.app_token", "API_TOKEN"),
-					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "settings.servicenow.instance", "US"),
-				),
-			},
-			// ImportState testing
-			{
-				ResourceName:      "swo_notification.test_servicenow",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and Read testing
-			{
-				Config: testAccServicenowConfig("test-acc test two"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test_servicenow", "title", "test-acc test two"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-func testAccServicenowConfig(title string) string {
-	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test_servicenow" {
-  		title       = %[1]q
-  		description = "testing..."
-  		type        = "servicenow"
-  		settings = {
-    		servicenow = {
-      			app_token = "API_TOKEN"
-      			instance  = "US"
-    		}
-		}
-	}`, title)
-}
-
 func TestAccSwsdNotificationResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -368,9 +420,10 @@ func TestAccSwsdNotificationResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test_swsd",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "swo_notification.test_swsd",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"settings.swsd.app_token"},
 			},
 			// Update and Read testing
 			{
@@ -398,53 +451,6 @@ func testAccSwsdConfig(title string) string {
 	}`, title)
 }
 
-func TestAccPushoverNotificationResource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		IsUnitTest:               true,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: testAccPushoverConfig("test-acc test one"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test_pushover", "type", "pushover"),
-					resource.TestCheckResourceAttr("swo_notification.test_pushover", "settings.pushover.app_token", "APP_TOKEN"),
-					resource.TestCheckResourceAttr("swo_notification.test_pushover", "settings.pushover.user_key", "123xyz"),
-				),
-			},
-			// ImportState testing
-			{
-				ResourceName:      "swo_notification.test_pushover",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and Read testing
-			{
-				Config: testAccPushoverConfig("test-acc test two"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test_pushover", "title", "test-acc test two"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-func testAccPushoverConfig(title string) string {
-	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test_pushover" {
-  		title       = %[1]q
-  		description = "testing..."
-  		type        = "pushover"
-  		settings = {
-    		pushover = {
-      			app_token = "APP_TOKEN"
-				user_key  = "123xyz"
-			}
-		}
-	}`, title)
-}
-
 func TestAccWebhookNotificationResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -458,18 +464,19 @@ func TestAccWebhookNotificationResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_notification.test_webhook", "type", "webhook"),
 					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.method", "GET"),
 					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.url", "https://webhook.example.com/"),
-					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_header_name", "X-Slack-Request-Id"),
-					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_header_value", "VALUE"),
-					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_password", "PASSWORD"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_header_name", "X-Request-Id"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_header_value", "HEADER_VALUE"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_password", "AUTH_PASSWORD"),
 					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_type", "basic"),
-					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_username", "USERNAME"),
+					resource.TestCheckResourceAttr("swo_notification.test_webhook", "settings.webhook.auth_username", "AUTH_USERNAME"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "swo_notification.test_webhook",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "swo_notification.test_webhook",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"settings.webhook.auth_password", "settings.webhook.auth_header_value"},
 			},
 			// Update and Read testing
 			{
@@ -492,11 +499,11 @@ func testAccWebhookConfig(title string) string {
     		webhook = {
       			method = "GET"
 				url    = "https://webhook.example.com/"
-				auth_header_name = "X-Slack-Request-Id"
-				auth_header_value = "VALUE"
-				auth_password = "PASSWORD"
+				auth_header_name = "X-Request-Id"
+				auth_header_value = "HEADER_VALUE"
+				auth_password = "AUTH_PASSWORD"
 				auth_type = "basic"
-				auth_username = "USERNAME"
+				auth_username = "AUTH_USERNAME"
 			}
 		}
 	}`, title)

--- a/internal/provider/notification_resource_test.go
+++ b/internal/provider/notification_resource_test.go
@@ -76,6 +76,8 @@ func TestAccAmazonSnsNotificationResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("swo_notification.test", "type", "amazonsns"),
 					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsn.access_key_id", "KEY_ID"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsn.secret_access_key", "SECRET_KEY"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsn.topic_arn", "arn:aws:sns:us-east-1:123456789012:topic"),
 				),
 			},
 			// ImportState testing
@@ -200,7 +202,7 @@ func testAccOpsGenieConfig(title string) string {
   		settings = {
     		opsgenie = {
       			hostname   = "hostname"
-      			apikey     = "API_KEY"
+      			api_key     = "API_KEY"
       			recipients = "alice"
       			teams      = "team1, team2"
       			tags       = "tag1, tag2"
@@ -297,98 +299,6 @@ func testAccPagerdutyConfig(title string) string {
     		routing_key = "99999999999999999999999999999999"
       		summary     = "some-summary"
       		dedup_key   = "DEDUP"
-		}
-	}`, title)
-}
-
-func TestAccVictorOpsNotificationResource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		IsUnitTest:               true,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: testAccVictorOpsConfig("test-acc test one"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "victorops"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.victorops.api_key", "API_KEY"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.victorops.routing_key", "ROUTING_KEY"),
-				),
-			},
-			// ImportState testing
-			{
-				ResourceName:      "swo_notification.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and Read testing
-			{
-				Config: testAccVictorOpsConfig("test-acc test two"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-func testAccVictorOpsConfig(title string) string {
-	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test_victorops" {
-  		title       = %[1]q
-  		description = "testing..."
-  		type        = "victorops"
-  		settings = {
-    		victorops = {
-      			api_key     = "API_KEY"
-      			routing_key = "ROUTING_KEY"
-    		}
-		}
-	}`, title)
-}
-
-func TestAccSmsNotificationResource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		IsUnitTest:               true,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: testAccSmsConfig("test-acc test one"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "type", "sms"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.sms.phone_numbers", "+1 999 999 9999"),
-				),
-			},
-			// ImportState testing
-			{
-				ResourceName:      "swo_notification.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and Read testing
-			{
-				Config: testAccSmsConfig("test-acc test two"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-func testAccSmsConfig(title string) string {
-	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test_sms" {
-  		title       = %[1]q
-  		description = "testing..."
-  		type        = "sms"
-  		settings = {
-    		sms = {
-      			phone_numbers = "+1 999 999 9999"
-    		}
 		}
 	}`, title)
 }

--- a/internal/provider/notification_resource_test.go
+++ b/internal/provider/notification_resource_test.go
@@ -81,10 +81,9 @@ func TestAccAmazonSnsNotificationResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:            "swo_notification.test_amazonsns",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"access_key_id", "secret_access_key"},
+				ResourceName:      "swo_notification.test_amazonsns",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/notification_resource_test.go
+++ b/internal/provider/notification_resource_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccNotificationResource(t *testing.T) {
+func TestAccEmailResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -15,7 +15,7 @@ func TestAccNotificationResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccNotificationResourceConfig("test-acc test one"),
+				Config: testAccEmailConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("swo_notification.test", "id"),
 					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test one"),
@@ -33,7 +33,7 @@ func TestAccNotificationResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccNotificationResourceConfig("test-acc test two"),
+				Config: testAccEmailConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
 				),
@@ -43,7 +43,7 @@ func TestAccNotificationResource(t *testing.T) {
 	})
 }
 
-func testAccNotificationResourceConfig(title string) string {
+func testAccEmailConfig(title string) string {
 	return providerConfig() + fmt.Sprintf(`
 	resource "swo_notification" "test" {
 		title        = %[1]q
@@ -75,9 +75,9 @@ func TestAccAmazonSnsNotificationResource(t *testing.T) {
 				Config: testAccAmazonSnsConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("swo_notification.test", "type", "amazonsns"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsn.access_key_id", "KEY_ID"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsn.secret_access_key", "SECRET_KEY"),
-					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsn.topic_arn", "arn:aws:sns:us-east-1:123456789012:topic"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsns.access_key_id", "KEY_ID"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsns.secret_access_key", "SECRET_KEY"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsns.topic_arn", "arn:aws:sns:us-east-1:123456789012:topic"),
 				),
 			},
 			// ImportState testing
@@ -105,9 +105,9 @@ func testAccAmazonSnsConfig(title string) string {
   		type        = "amazonsns"
   		settings = {
     		amazonsns = {
+				topic_arn = "arn:aws:sns:us-east-1:123456789012:topic"
 				access_key_id = "KEY_ID"
 				secret_access_key = "SECRET_KEY"
-				topic_arn = "arn:aws:sns:us-east-1:123456789012:topic"
 			}
 		}
 	}`, title)
@@ -152,7 +152,7 @@ func testAccMsTeamsConfig(title string) string {
   		type        = "msTeams"
   		settings = {
     		msteams = {
-      			url = "https://www.office.com/webhook"
+      			url = "https://solarwinds.webhook.office.com/webhookb2/d31597c"
 			}
 		}
 	}`, title)
@@ -540,7 +540,7 @@ func testAccZapierConfig(title string) string {
   		type        = "zapier"
   		settings = {
     		zapier = {
-      			url = "https://www.office.com/webhook"
+      			url = "https://hooks.zapier.com/hooks/catch/123567/abcdef/"
 			}
 		}
 	}`, title)

--- a/internal/provider/notification_resource_test.go
+++ b/internal/provider/notification_resource_test.go
@@ -514,7 +514,7 @@ func TestAccZapierNotificationResource(t *testing.T) {
 				Config: testAccZapierConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("swo_notification.test_zapier", "type", "zapier"),
-					resource.TestCheckResourceAttr("swo_notification.test_zapier", "settings.zapier.url", "https://hooks.zapier.com/hooks/catch/123567/abcdef/"),
+					resource.TestCheckResourceAttr("swo_notification.test_zapier", "settings.zapier.url", "https://hooks.zapier.com/hooks/catch/XXX"),
 				),
 			},
 			// ImportState testing
@@ -542,7 +542,7 @@ func testAccZapierConfig(title string) string {
   		type        = "zapier"
   		settings = {
     		zapier = {
-      			url = "https://hooks.zapier.com/hooks/catch/123567/abcdef/"
+      			url = "https://hooks.zapier.com/hooks/catch/XXX"
 			}
 		}
 	}`, title)

--- a/internal/provider/notification_resource_test.go
+++ b/internal/provider/notification_resource_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccNotificationResource(t *testing.T) {
+func TestAccEmailNotificationResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -15,7 +15,7 @@ func TestAccNotificationResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccNotificationResourceConfig("test-acc test one"),
+				Config: testAccEmailConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("swo_notification.test", "id"),
 					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test one"),
@@ -33,7 +33,7 @@ func TestAccNotificationResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccNotificationResourceConfig("test-acc test two"),
+				Config: testAccEmailConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
 				),
@@ -42,10 +42,9 @@ func TestAccNotificationResource(t *testing.T) {
 		},
 	})
 }
-
-func testAccNotificationResourceConfig(title string) string {
+func testAccEmailConfig(title string) string {
 	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test" {
+	resource "swo_notification" "test_email" {
 		title        = %[1]q
 		description = "testing..."
 		type = "email"
@@ -59,6 +58,577 @@ func testAccNotificationResourceConfig(title string) string {
 						email = "test2@host.com"
 					},
 				]
+			}
+		}
+	}`, title)
+}
+
+func TestAccAmazonSnsNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccAmazonSnsConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "amazonsns"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.amazonsn.access_key_id", "KEY_ID"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccAmazonSnsConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccAmazonSnsConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_amazon_sns" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "amazonsns"
+  		settings = {
+    		amazonsn = {
+				access_key_id = "KEY_ID"
+				secret_access_key = "SECRET_KEY"
+				topic_arn = "arn:aws:sns:us-east-1:123456789012:topic"
+		}
+	}`, title)
+}
+
+func TestAccMsTeamsNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccMsTeamsConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "msTeams"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.msteams.url", "https://www.office.com/webhook"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccMsTeamsConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccMsTeamsConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_msteams" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "msTeams"
+  		settings = {
+    		msteams = {
+      			url = "https://www.office.com/webhook"
+			}
+		}
+	}`, title)
+}
+
+func TestAccOpsGenieNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccOpsGenieConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "opsgenie"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.hostname", "hostname"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.apikey", "API_KEY"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.recipients", "alice"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.teams", "team1, team2"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.opsgenie.tags", "tag1, tag2"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccOpsGenieConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccOpsGenieConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_opsgenie" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "opsgenie"
+  		settings = {
+    		opsgenie = {
+      			hostname   = "hostname"
+      			apikey     = "API_KEY"
+      			recipients = "alice"
+      			teams      = "team1, team2"
+      			tags       = "tag1, tag2"
+			}
+		}
+	}`, title)
+}
+
+func TestAccSlackNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccSlackConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "slack"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.slack.url", "https://hooks.slack.com/services/XXX/XXX/XXX"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccSlackConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccSlackConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_slack" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "slack"
+  		settings = {
+    		slack = {
+      			url = "https://hooks.slack.com/services/XXX/XXX/XXX"
+    		}
+		}
+	}`, title)
+}
+
+func TestAccPagerDutyNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccPagerdutyConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "pagerduty"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.pagerduty.routing_key", "99999999999999999999999999999999"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.pagerduty.summary", "some-summary"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.pagerduty.dedup_key", "DEDUP"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccPagerdutyConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccPagerdutyConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_pagerduty" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "pagerduty"
+  		settings = {
+    		routing_key = "99999999999999999999999999999999"
+      		summary     = "some-summary"
+      		dedup_key   = "DEDUP"
+		}
+	}`, title)
+}
+
+func TestAccVictorOpsNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccVictorOpsConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "victorops"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.victorops.api_key", "API_KEY"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.victorops.routing_key", "ROUTING_KEY"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccVictorOpsConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccVictorOpsConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_victorops" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "victorops"
+  		settings = {
+    		victorops = {
+      			api_key     = "API_KEY"
+      			routing_key = "ROUTING_KEY"
+    		}
+		}
+	}`, title)
+}
+
+func TestAccSmsNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccSmsConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "sms"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.sms.phone_numbers", "+1 999 999 9999"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccSmsConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccSmsConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_sms" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "sms"
+  		settings = {
+    		sms = {
+      			phone_numbers = "+1 999 999 9999"
+    		}
+		}
+	}`, title)
+}
+
+func TestAccServiceNowNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccServicenowConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "servicenow"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.servicenow.app_token", "API_TOKEN"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.servicenow.instance", "US"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccServicenowConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccServicenowConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_servicenow" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "servicenow"
+  		settings = {
+    		servicenow = {
+      			app_token = "API_TOKEN"
+      			instance  = "US"
+    		}
+		}
+	}`, title)
+}
+
+func TestAccSwsdNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccSwsdConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "swsd"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.swsd.app_token", "APP_TOKEN"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.swsd.is_eu", "false"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccSwsdConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccSwsdConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_swsd" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "swsd"
+  		settings = {
+    		swsd = {
+      			app_token = "APP_TOKEN"
+      			is_eu     = false
+    		}
+		}
+	}`, title)
+}
+
+func TestAccPushoverNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccPushoverConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "pushover"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.pushover.app_token", "APP_TOKEN"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.pushover.user_key", "123xyz"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccPushoverConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccPushoverConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_pushover" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "pushover"
+  		settings = {
+    		pushover = {
+      			app_token = "APP_TOKEN"
+				user_key  = "123xyz"
+			}
+		}
+	}`, title)
+}
+
+func TestAccWebhookNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccWebhookConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "webhook"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.method", "GET"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.url", "https://webhook.example.com/"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_header_name", "X-Slack-Request-Id"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_header_value", "VALUE"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_password", "PASSWORD"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_type", "basic"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.webhook.auth_username", "USERNAME"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccWebhookConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccWebhookConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_webhook" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "webhook"
+  		settings = {
+    		webhook = {
+      			method = "GET"
+				url    = "https://webhook.example.com/"
+				auth_header_name = "X-Slack-Request-Id"
+				auth_header_value = "VALUE"
+				auth_password = "PASSWORD"
+				auth_type = "basic"
+				auth_username = "USERNAME"
+			}
+		}
+	}`, title)
+}
+
+func TestAccZapierNotificationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccZapierConfig("test-acc test one"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "type", "zapier"),
+					resource.TestCheckResourceAttr("swo_notification.test", "settings.zapier.url", "https://www.office.com/webhook"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "swo_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccZapierConfig("test-acc test two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+func testAccZapierConfig(title string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_notification" "test_zapier" {
+  		title       = %[1]q
+  		description = "testing..."
+  		type        = "zapier"
+  		settings = {
+    		zapier = {
+      			url = "https://www.office.com/webhook"
 			}
 		}
 	}`, title)

--- a/internal/provider/notification_resource_test.go
+++ b/internal/provider/notification_resource_test.go
@@ -171,7 +171,7 @@ func TestAccOpsGenieNotificationResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "type", "opsgenie"),
 					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.hostname", "hostname"),
 					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.api_key", "API_KEY"),
-					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.recipients", "alice"),
+					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.recipients", "on-call recipient"),
 					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.teams", "team1, team2"),
 					resource.TestCheckResourceAttr("swo_notification.test_opsgenie", "settings.opsgenie.tags", "tag1, tag2"),
 				),
@@ -204,7 +204,7 @@ func testAccOpsGenieConfig(title string) string {
     		opsgenie = {
       			hostname   = "hostname"
       			api_key     = "API_KEY"
-      			recipients = "alice"
+      			recipients = "on-call recipient"
       			teams      = "team1, team2"
       			tags       = "tag1, tag2"
 			}

--- a/internal/provider/notification_resource_test.go
+++ b/internal/provider/notification_resource_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccEmailNotificationResource(t *testing.T) {
+func TestAccNotificationResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -15,7 +15,7 @@ func TestAccEmailNotificationResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccEmailConfig("test-acc test one"),
+				Config: testAccNotificationResourceConfig("test-acc test one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("swo_notification.test", "id"),
 					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test one"),
@@ -33,7 +33,7 @@ func TestAccEmailNotificationResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccEmailConfig("test-acc test two"),
+				Config: testAccNotificationResourceConfig("test-acc test two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("swo_notification.test", "title", "test-acc test two"),
 				),
@@ -42,9 +42,10 @@ func TestAccEmailNotificationResource(t *testing.T) {
 		},
 	})
 }
-func testAccEmailConfig(title string) string {
+
+func testAccNotificationResourceConfig(title string) string {
 	return providerConfig() + fmt.Sprintf(`
-	resource "swo_notification" "test_email" {
+	resource "swo_notification" "test" {
 		title        = %[1]q
 		description = "testing..."
 		type = "email"
@@ -101,10 +102,11 @@ func testAccAmazonSnsConfig(title string) string {
   		description = "testing..."
   		type        = "amazonsns"
   		settings = {
-    		amazonsn = {
+    		amazonsns = {
 				access_key_id = "KEY_ID"
 				secret_access_key = "SECRET_KEY"
 				topic_arn = "arn:aws:sns:us-east-1:123456789012:topic"
+			}
 		}
 	}`, title)
 }

--- a/internal/provider/notification_schema.go
+++ b/internal/provider/notification_schema.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	emailRegex               = `^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$`
-	phoneNumberRegex         = `^\+(?:[0-9] ?){6,14}[0-9]$`
 	snsTopicArnRegex         = `^arn:aws:sns:[^:]+:[0-9]+:[a-zA-Z0-9\-_]+$`
 	zapierHooksRegex         = `^https:\/\/hooks\.zapier\.com\/hooks\/catch.*`
 	slackHooksRegex          = `^https:\/\/hooks\.slack\.com.*`
@@ -204,22 +203,6 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 							},
 						},
 					},
-					"victorops": schema.SingleNestedAttribute{
-						Description: "Integration for sending events to VictorOps.",
-						Optional:    true,
-						Attributes: map[string]schema.Attribute{
-							"api_key": schema.StringAttribute{
-								Description: "API Key for a VictorOps integration. (https://help.victorops.com/knowledge-base/api/)",
-								Required:    true,
-								Sensitive:   true,
-							},
-							"routing_key": schema.StringAttribute{
-								Description: "Key for live call routing. (https://help.victorops.com/knowledge-base/routing-keys/)",
-								Optional:    true,
-								Sensitive:   true,
-							},
-						},
-					},
 					"opsgenie": schema.SingleNestedAttribute{
 						Description: "Integration for sending alerts via email or using a Webhook to OpsGenie.",
 						Optional:    true,
@@ -316,22 +299,6 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "API token/APP token from registered Pushover application. (https://pushover.net/api)",
 								Required:    true,
 								Sensitive:   true,
-							},
-						},
-					},
-					"sms": schema.SingleNestedAttribute{
-						Description: "For sending alerts Through SMS/Text.",
-						Optional:    true,
-						Attributes: map[string]schema.Attribute{
-							"phone_numbers": schema.StringAttribute{
-								Description: "Phone number alerts will be texted to.",
-								Required:    true,
-								Validators: []validator.String{
-									stringvalidator.RegexMatches(
-										regexp.MustCompile(phoneNumberRegex),
-										"Requirement: "+phoneNumberRegex,
-									),
-								},
 							},
 						},
 					},

--- a/internal/provider/notification_schema.go
+++ b/internal/provider/notification_schema.go
@@ -153,7 +153,7 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 								},
 							},
 							"dedup_key": schema.StringAttribute{
-								Description: "deduplication key for correlating trigger conditions. (https://support.pagerduty.com/docs/event-management) ",
+								Description: "Deduplication key for correlating trigger conditions. (https://support.pagerduty.com/docs/event-management) ",
 								Required:    true,
 							},
 						},

--- a/internal/provider/notification_schema.go
+++ b/internal/provider/notification_schema.go
@@ -39,11 +39,12 @@ func newParseError(msg string) error {
 
 // The main Notification Resource model that is derived from the schema.
 type notificationResourceModel struct {
-	Id          types.String          `tfsdk:"id"`
-	Title       types.String          `tfsdk:"title"`
-	Description types.String          `tfsdk:"description"`
-	Type        types.String          `tfsdk:"type"`
-	Settings    *notificationSettings `tfsdk:"settings"`
+	Id          types.String `tfsdk:"id"`
+	Title       types.String `tfsdk:"title"`
+	Description types.String `tfsdk:"description"`
+	Type        types.String `tfsdk:"type"`
+	//Settings    *notificationSettings `tfsdk:"settings"`
+	Settings types.Object `tfsdk:"settings"`
 }
 
 func ParseNotificationId(id types.String) (idValue string, notificationType string, err error) {

--- a/internal/provider/notification_schema.go
+++ b/internal/provider/notification_schema.go
@@ -43,8 +43,7 @@ type notificationResourceModel struct {
 	Title       types.String `tfsdk:"title"`
 	Description types.String `tfsdk:"description"`
 	Type        types.String `tfsdk:"type"`
-	//Settings    *notificationSettings `tfsdk:"settings"`
-	Settings types.Object `tfsdk:"settings"`
+	Settings    types.Object `tfsdk:"settings"`
 }
 
 func ParseNotificationId(id types.String) (idValue string, notificationType string, err error) {

--- a/internal/provider/notification_schema.go
+++ b/internal/provider/notification_schema.go
@@ -141,6 +141,9 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 										"Requirement: "+pagerDutyRoutingKeyRegex,
 									),
 								},
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 							"summary": schema.StringAttribute{
 								Description: "A summary of the issue causing the alert to trigger.",
@@ -191,6 +194,9 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "Password for basic auth type.",
 								Optional:    true,
 								Sensitive:   true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 							"auth_header_name": schema.StringAttribute{
 								Description: "Header name for token auth.",
@@ -200,6 +206,9 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "Header value for token auth.",
 								Optional:    true,
 								Sensitive:   true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 						},
 					},
@@ -215,6 +224,9 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "API key from OpsGenie Integration. (https://support.atlassian.com/opsgenie/docs/api-key-management/)",
 								Required:    true,
 								Sensitive:   true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 							"recipients": schema.StringAttribute{
 								Description: "Specifies who should be notified by email for the alert.",
@@ -252,6 +264,9 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "Secret access key for Amazon SNS.",
 								Required:    true,
 								Sensitive:   true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 						},
 					},
@@ -299,6 +314,9 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "API token/APP token from registered Pushover application. (https://pushover.net/api)",
 								Required:    true,
 								Sensitive:   true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 						},
 					},
@@ -310,6 +328,9 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "Token copied from SolarWinds Service Desk",
 								Required:    true,
 								Sensitive:   true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 							"is_eu": schema.BoolAttribute{
 								Description: "Is in the EU.",
@@ -325,6 +346,9 @@ func (r *notificationResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "ServiceNow access token",
 								Required:    true,
 								Sensitive:   true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 							"instance": schema.StringAttribute{
 								Description: "Instance name for this integration",

--- a/internal/provider/notification_schema.go
+++ b/internal/provider/notification_schema.go
@@ -24,7 +24,7 @@ const (
 	zapierHooksRegex         = `^https:\/\/hooks\.zapier\.com\/hooks\/catch.*`
 	slackHooksRegex          = `^https:\/\/hooks\.slack\.com.*`
 	pagerDutyRoutingKeyRegex = `^[a-zA-Z0-9]{32}$`
-	msTeamsRegex             = `^https:\/\/.*\.office\.com\/webhook.*`
+	msTeamsRegex             = `^https://[a-zA-Z0-9.-]+.webhook.office.com/webhookb2/[a-zA-Z0-9@-]+`
 	httpSchemeRegex          = `^(http|https)`
 )
 


### PR DESCRIPTION
Changes in this PR:

- Migrate to TF types. This required rewriting `Get()` and `Set()` for all types, and creating new models for the client and TF. 
- Refactor error handling to use `Diagnostics`
- Add handling for sensitive attributes. For any sensitive attribute, TF cannot detect or store the actual value because it's masked. This causes state drift or prevents the value from being updated in state.
- Add custom `Set()` for each type with a sensitive attribute.
- In schema, apply `PlanModifier: RequiresReplace()` to indicates that any change in this field requires the resource to be destroyed and recreated.
- Update acceptance tests during the Import State to not compare sensitive values as it is masked.
- Remove OBE types `victorops` and `sms` → not supported in SWO or AO, and as such should not be available. (Also not available for alert resource, where this resource would be used.)
- Add acceptance test for each type
- Normalize documentation, example resources, and test data