### PR TITLE
fix(composte_metrics) nil displayName is causing the provider to panic

### DIFF
--- a/docs/resources/compositemetric.md
+++ b/docs/resources/compositemetric.md
@@ -27,10 +27,13 @@ resource "swo_compositemetric" "disk_io_rate" {
 
 ### Required
 
-- `description` (String) Description of the composite metric. A detailed description of the metric.
-- `display_name` (String) Display name of the composite metric. A short description of the metric.
 - `formula` (String) PromQL query to calculate the composite metric. example: rate(system.disk.io[5m])
 - `name` (String) The metric name.
+
+### Optional
+
+- `description` (String) Description of the composite metric. A detailed description of the metric.
+- `display_name` (String) Display name of the composite metric. A short description of the metric.
 - `unit` (String) Unit of the composite metric. example: bytes/s
 
 ### Read-Only

--- a/internal/provider/composite_metric_resource.go
+++ b/internal/provider/composite_metric_resource.go
@@ -163,28 +163,22 @@ func (r *compositeMetricResource) ImportState(ctx context.Context, req resource.
 	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
 }
 
-func (r *compositeMetricResource) updatePlanFromMetric(tfPlan compositeMetricResourceModel, name string, displayName *string, description *string, formula string, units *string) compositeMetricResourceModel {
+func (r *compositeMetricResource) updatePlanFromMetric(tfPlan compositeMetricResourceModel, name string, displayName *string, description *string, formula *string, units *string) compositeMetricResourceModel {
 	tfPlan.Name = types.StringValue(name)
 	tfPlan.Id = tfPlan.Name
 	tfPlan.DisplayName = types.StringPointerValue(displayName)
 	tfPlan.Description = types.StringPointerValue(description)
-	tfPlan.Formula = types.StringValue(formula)
+	tfPlan.Formula = types.StringPointerValue(formula)
 	tfPlan.Unit = types.StringPointerValue(units)
 
 	return tfPlan
 }
 
 func (r *compositeMetricResource) updatePlanMetricInfo(tfPlan compositeMetricResourceModel, compositeMetric *components.CompositeMetric) compositeMetricResourceModel {
-	return r.updatePlanFromMetric(tfPlan, compositeMetric.Name, compositeMetric.DisplayName, compositeMetric.Description, compositeMetric.Formula, compositeMetric.Units)
+	formula := compositeMetric.Formula
+	return r.updatePlanFromMetric(tfPlan, compositeMetric.Name, compositeMetric.DisplayName, compositeMetric.Description, &formula, compositeMetric.Units)
 }
 
 func (r *compositeMetricResource) updatePlanCommonMetricInfo(tfPlan compositeMetricResourceModel, compositeMetric *components.CommonMetricInfo) compositeMetricResourceModel {
-	tfPlan.Name = types.StringValue(compositeMetric.Name)
-	tfPlan.Id = tfPlan.Name
-	tfPlan.DisplayName = types.StringPointerValue(compositeMetric.DisplayName)
-	tfPlan.Description = types.StringPointerValue(compositeMetric.Description)
-	tfPlan.Formula = types.StringPointerValue(compositeMetric.Formula)
-	tfPlan.Unit = types.StringPointerValue(compositeMetric.Units)
-
-	return tfPlan
+	return r.updatePlanFromMetric(tfPlan, compositeMetric.Name, compositeMetric.DisplayName, compositeMetric.Description, compositeMetric.Formula, compositeMetric.Units)
 }

--- a/internal/provider/composite_metric_resource.go
+++ b/internal/provider/composite_metric_resource.go
@@ -36,14 +36,6 @@ func NewCompositeMetricResource() resource.Resource {
 	return &compositeMetricResource{}
 }
 
-// stringPtrValue safely dereferences a string pointer, returning empty string if nil
-func stringPtrValue(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
 func (r *compositeMetricResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	client, _ := req.ProviderData.(providerClients)
 	r.client = client.SwoV1Client

--- a/internal/provider/composite_metric_resource.go
+++ b/internal/provider/composite_metric_resource.go
@@ -166,10 +166,10 @@ func (r *compositeMetricResource) ImportState(ctx context.Context, req resource.
 func (r *compositeMetricResource) updatePlanFromMetric(tfPlan compositeMetricResourceModel, name string, displayName *string, description *string, formula string, units *string) compositeMetricResourceModel {
 	tfPlan.Name = types.StringValue(name)
 	tfPlan.Id = tfPlan.Name
-	tfPlan.DisplayName = types.StringValue(stringPtrValue(displayName))
-	tfPlan.Description = types.StringValue(stringPtrValue(description))
+	tfPlan.DisplayName = types.StringPointerValue(displayName)
+	tfPlan.Description = types.StringPointerValue(description)
 	tfPlan.Formula = types.StringValue(formula)
-	tfPlan.Unit = types.StringValue(stringPtrValue(units))
+	tfPlan.Unit = types.StringPointerValue(units)
 
 	return tfPlan
 }
@@ -179,5 +179,12 @@ func (r *compositeMetricResource) updatePlanMetricInfo(tfPlan compositeMetricRes
 }
 
 func (r *compositeMetricResource) updatePlanCommonMetricInfo(tfPlan compositeMetricResourceModel, compositeMetric *components.CommonMetricInfo) compositeMetricResourceModel {
-	return r.updatePlanFromMetric(tfPlan, compositeMetric.Name, compositeMetric.DisplayName, compositeMetric.Description, stringPtrValue(compositeMetric.Formula), compositeMetric.Units)
+	tfPlan.Name = types.StringValue(compositeMetric.Name)
+	tfPlan.Id = tfPlan.Name
+	tfPlan.DisplayName = types.StringPointerValue(compositeMetric.DisplayName)
+	tfPlan.Description = types.StringPointerValue(compositeMetric.Description)
+	tfPlan.Formula = types.StringPointerValue(compositeMetric.Formula)
+	tfPlan.Unit = types.StringPointerValue(compositeMetric.Units)
+
+	return tfPlan
 }

--- a/internal/provider/composite_metric_resource_test.go
+++ b/internal/provider/composite_metric_resource_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestAccCompositeMetricResource(t *testing.T) {
+	// Tests basic CRUD.
+	metricName := "composite.testacc.basic"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -15,9 +18,9 @@ func TestAccCompositeMetricResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccCompositeMetricResourceConfig("composite.testacc", "display name one"),
+				Config: testAccCompositeMetricResourceConfig(metricName, "display name one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", "composite.testacc"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", metricName),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "display_name", "display name one"),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "description", "test-acc composite metric description"),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "rate(system.disk.io[5m])"),
@@ -33,16 +36,81 @@ func TestAccCompositeMetricResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccCompositeUpdateMetricResourceConfig("composite.testacc", "display name two"),
+				Config: testAccCompositeUpdateMetricResourceConfig(metricName, "display name two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", "composite.testacc"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", metricName),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "display_name", "display name two"),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "description", "Update metric description"),
-					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "SUM(synthetics.https.response.time)"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "avg(system.memory.used)"),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "unit", "m/s"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccCompositeMetricResourceOptionalFields(t *testing.T) {
+	// Tests that the provider handles optional fields being nil/present gracefully
+	metricName := "composite.testacc.optional.fields"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create metric with minimal required fields only
+			{
+				Config: testAccCompositeMetricMinimalConfig(metricName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", metricName),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "sum(synthetics.https.response.time)"),
+					resource.TestCheckResourceAttrSet("swo_compositemetric.test", "id"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "swo_compositemetric.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"description", "display_name", "unit"},
+			},
+			// Add optional fields via update
+			{
+				Config: testAccCompositeMetricWithOptionalFieldsConfig(metricName, "Added Display Name", "Added Description", "ms"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", metricName),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "sum(synthetics.https.response.time)"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "display_name", "Added Display Name"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "description", "Added Description"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "unit", "ms"),
+				),
+			},
+			// Tests that the provider handles API responses with nil optional fields gracefully
+			// (this could happen after UI edits)
+			{
+				RefreshState: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", metricName),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "sum(synthetics.https.response.time)"),
+					resource.TestCheckResourceAttrSet("swo_compositemetric.test", "display_name"),
+					resource.TestCheckResourceAttrSet("swo_compositemetric.test", "description"),
+					resource.TestCheckResourceAttrSet("swo_compositemetric.test", "unit"),
+				),
+			},
+			// Verifies optional fields are removed
+			{
+				Config: testAccCompositeMetricMinimalConfig(metricName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", metricName),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "sum(synthetics.https.response.time)"),
+					resource.TestCheckResourceAttrSet("swo_compositemetric.test", "id"),
+					// Verify optional fields are completely absent after removal
+					resource.TestCheckNoResourceAttr("swo_compositemetric.test", "display_name"),
+					resource.TestCheckNoResourceAttr("swo_compositemetric.test", "description"),
+					resource.TestCheckNoResourceAttr("swo_compositemetric.test", "unit"),
+				),
+			},
 		},
 	})
 }
@@ -64,7 +132,27 @@ func testAccCompositeUpdateMetricResourceConfig(name string, displayName string)
 		name        = %[1]q
 		display_name = %[2]q
 		description = "Update metric description"
-		formula = "SUM(synthetics.https.response.time)"
+		formula = "avg(system.memory.used)"
 		unit = "m/s"
 	}`, name, displayName)
+}
+
+func testAccCompositeMetricWithOptionalFieldsConfig(name string, displayName string, description string, unit string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_compositemetric" "test" {
+		name        = %[1]q
+		display_name = %[2]q
+		description = %[3]q
+		formula = "sum(synthetics.https.response.time)"
+		unit = %[4]q
+	}`, name, displayName, description, unit)
+}
+
+func testAccCompositeMetricMinimalConfig(name string) string {
+	return providerConfig() + fmt.Sprintf(`
+	resource "swo_compositemetric" "test" {
+		name    = %[1]q
+		formula = "sum(synthetics.https.response.time)"
+		# Omitting optional fields: display_name, description, unit
+	}`, name)
 }

--- a/internal/provider/composite_metric_resource_test.go
+++ b/internal/provider/composite_metric_resource_test.go
@@ -41,7 +41,7 @@ func TestAccCompositeMetricResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "name", metricName),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "display_name", "display name two"),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "description", "Update metric description"),
-					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "avg(system.memory.used)"),
+					resource.TestCheckResourceAttr("swo_compositemetric.test", "formula", "SUM(synthetics.https.response.time)"),
 					resource.TestCheckResourceAttr("swo_compositemetric.test", "unit", "m/s"),
 				),
 			},
@@ -132,7 +132,7 @@ func testAccCompositeUpdateMetricResourceConfig(name string, displayName string)
 		name        = %[1]q
 		display_name = %[2]q
 		description = "Update metric description"
-		formula = "avg(system.memory.used)"
+		formula = "SUM(synthetics.https.response.time)"
 		unit = "m/s"
 	}`, name, displayName)
 }

--- a/internal/provider/composite_metric_schema.go
+++ b/internal/provider/composite_metric_schema.go
@@ -30,11 +30,11 @@ func (r *compositeMetricResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"display_name": schema.StringAttribute{
 				Description: "Display name of the composite metric. A short description of the metric.",
-				Required:    true,
+				Optional:    true,
 			},
 			"description": schema.StringAttribute{
 				Description: "Description of the composite metric. A detailed description of the metric.",
-				Required:    true,
+				Optional:    true,
 			},
 			"formula": schema.StringAttribute{
 				Description: "PromQL query to calculate the composite metric. example: rate(system.disk.io[5m])",
@@ -42,7 +42,7 @@ func (r *compositeMetricResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"unit": schema.StringAttribute{
 				Description: "Unit of the composite metric. example: bytes/s",
-				Required:    true,
+				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -11,13 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func stringPtrValue(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
 func convertArray[A, B any](source []A, accumulator func(A) B) []B {
 	if source == nil {
 		return nil

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -4,11 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"net/url"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func stringPtrValue(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
 
 func convertArray[A, B any](source []A, accumulator func(A) B) []B {
 	if source == nil {

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"net/url"
+	"strings"
 )
 
 func convertArray[A, B any](source []A, accumulator func(A) B) []B {


### PR DESCRIPTION
There is an ongoing issue where the `displayName` field gets set to nil if any composite metric field is edited in the SWO UI. This caused the provider to crash whenever `displayName` returned a nil value from the API response.

To fix this and prevent similar crashes for other optional fields, all fields that are not required by the Public REST API were changed from `Required: true` to `Optional: true` in the schema. Additionally, we now safely handle all string pointers rather than causing a panic like direct dereferencing with `*pointer` does.

**Note** If a composite metric created in Terraform is subsequently edited in the SWO UI, the `displayName` field may be set to nil by the API and will show as null in the Terraform state after a `terraform refresh`.