### PR TITLE
[bug] alerts_resource target_entity_types is optional

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -73,7 +73,7 @@ resource "swo_alert" "https_response_time" {
 - `notification_actions` (Attributes Set) List of alert notifications that are sent when an alert triggers. (see [below for nested schema](#nestedatt--notification_actions))
 - `notifications` (List of String, Deprecated) A list of notifications that should be triggered for this alert.
 - `runbook_link` (String) A runbook is documentation of what steps to follow when something goes wrong.
-- `trigger_delay_seconds` (Number) Trigger the alert after the alert condition persists for a specific duration. This prevents false positives. Value must be between 60 and 86400 seconds, and value has to be divisible by 60. Default is `0`.
+- `trigger_delay_seconds` (Number) Trigger the alert after the alert condition persists for a specific duration. This prevents false positives. Value must be between 60 and 86400 seconds, and value must be divisible by 60. Default is `0`.
 - `trigger_reset_actions` (Boolean) True if a notification should be sent when an active alert returns to normal. Default is false. Default is `false`.
 
 ### Read-Only
@@ -88,7 +88,6 @@ Required:
 - `aggregation_type` (String) The aggregation function that will be applied to the metric. Valid values are [`AVG`|`COUNT`|`LAST`|`MAX`|`MIN`|`SUM`].
 - `duration` (String) The duration window determines how frequently the alert is evaluated.
 - `metric_name` (String) The field name of the metric to be filtered on.
-- `target_entity_types` (List of String) The entity types that the alert will be applied to. Must match across all alert conditions.
 - `threshold` (String) Operator and value that represent the threshold of an the alert. When the threshold is breached it triggers the alert. For Operator - binaryOperator:(=|!=|>|<|>=|<=), logicalOperator:(AND|OR) E.g. '>=10'
 
 Optional:
@@ -99,6 +98,7 @@ Optional:
 - `include_tags` (Attributes Set) Tag key and values to match in order to trigger an alert. (see [below for nested schema](#nestedatt--conditions--include_tags))
 - `not_reporting` (Boolean) True if the alert should trigger when the metric is not reporting. If true, threshold must be '' and aggregation_type must be 'COUNT'. Default is `false`.
 - `query_search` (String) Case-sensitive. System will automatically match existing and newly added entities matching the following query string.
+- `target_entity_types` (List of String) The entity types that the alert will be applied to. Must match across all alert conditions.
 
 <a id="nestedatt--conditions--exclude_tags"></a>
 ### Nested Schema for `conditions.exclude_tags`
@@ -128,4 +128,4 @@ Required:
 
 Optional:
 
-- `resend_interval_seconds` (Number) How often should the notification be resent in case alert keeps being triggered. Null means notification is sent only once. Valid values are 60, 600, 3600, 86400.
+- `resend_interval_seconds` (Number) How often should the notification be resent in case alert keeps being triggered. Null means notification is sent only once. Value must be between 60 and 86400 seconds, and value must be divisible by 60.

--- a/internal/provider/alert_resource_acc_test.go
+++ b/internal/provider/alert_resource_acc_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAlertResource(t *testing.T) {
+func TestAccEntityAlertResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -15,10 +15,10 @@ func TestAccAlertResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccAlertResourceConfig("test-acc Mock Alert Name"),
+				Config: testAccEntityAlertResourceConfig("test-acc Mock Entity Alert Name"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					//resource.TestCheckResourceAttr("swo_alert.test", "id", "0bc4710d-e3b0-4590-9c9b-e5e46d81d912"),
-					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc Mock Alert Name"),
+					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc Mock Entity Alert Name"),
 					resource.TestCheckResourceAttr("swo_alert.test", "description", "Mock alert description."),
 					resource.TestCheckResourceAttr("swo_alert.test", "severity", "CRITICAL"),
 					resource.TestCheckResourceAttr("swo_alert.test", "trigger_reset_actions", "false"),
@@ -59,9 +59,68 @@ func TestAccAlertResource(t *testing.T) {
 			}*/
 			// Update and Read testing
 			{
-				Config: testAccAlertResourceConfig("test-acc test_two"),
+				Config: testAccEntityAlertResourceConfig("test-acc test_two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc test_two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccMetricGroupAlertResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccMetricGroupAlertResourceConfig("test-acc Mock Metric Group Alert"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					//resource.TestCheckResourceAttr("swo_alert.test", "id", "0bc4710d-e3b0-4590-9c9b-e5e46d81d912"),
+					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc Mock Metric Group Alert"),
+					resource.TestCheckResourceAttr("swo_alert.test", "description", "Mock alert description."),
+					resource.TestCheckResourceAttr("swo_alert.test", "severity", "CRITICAL"),
+					resource.TestCheckResourceAttr("swo_alert.test", "trigger_reset_actions", "false"),
+					// Verify actions
+					resource.TestCheckResourceAttr("swo_alert.test", "notification_actions.0.configuration_ids.0", "333:email"),
+					resource.TestCheckResourceAttr("swo_alert.test", "notification_actions.0.configuration_ids.1", "444:msteams"),
+					resource.TestCheckResourceAttr("swo_alert.test", "notification_actions.0.resend_interval_seconds", "600"),
+					// Verify number of conditions.
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.#", "1"),
+					// Verify the conditions.
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.metric_name", "synthetics.https.response.time"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.threshold", ">=3000ms"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.not_reporting", "false"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.duration", "5m"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.aggregation_type", "AVG"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.query_search", "healthScore.categoryV2:bad"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.group_by_metric_tag.0", "host.name"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.include_tags.0.name", "probe.city"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.include_tags.0.values.0", "Tokyo"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.include_tags.0.values.1", "Sao Paulo"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.exclude_tags.0.name", "service.name"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.exclude_tags.0.values.0", "test-service"),
+
+					resource.TestCheckResourceAttr("swo_alert.test", "notifications.0", "123"),
+					resource.TestCheckResourceAttr("swo_alert.test", "notifications.1", "456"),
+					resource.TestCheckResourceAttr("swo_alert.test", "runbook_link", "https://www.runbooklink.com"),
+					resource.TestCheckResourceAttr("swo_alert.test", "trigger_delay_seconds", "300"),
+				),
+			},
+			// ImportState testing
+			/*{
+				ResourceName:      "swo_alert.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			}*/
+			// Update and Read testing
+			{
+				Config: testAccMetricGroupAlertResourceConfig("test-acc Mock Metric Group Alert 2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc Mock Metric Group Alert 2"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -202,7 +261,7 @@ func TestMultiConditionAlertResource(t *testing.T) {
 	})
 }
 
-func testAccAlertResourceConfig(name string) string {
+func testAccEntityAlertResourceConfig(name string) string {
 	return providerConfig() + fmt.Sprintf(`
 
 resource "swo_alert" "test" {
@@ -375,6 +434,55 @@ resource "swo_alert" "test" {
   ]
   notifications = ["123", "456"]
   runbook_link = "https://www.runbooklink.com"
+}
+`, name)
+}
+
+func testAccMetricGroupAlertResourceConfig(name string) string {
+	return providerConfig() + fmt.Sprintf(`
+
+resource "swo_alert" "test" {
+ name        = %[1]q
+ description = "Mock alert description."
+ severity    = "CRITICAL"
+ enabled     = true
+ notification_actions = [
+   {
+	  configuration_ids = ["333:email", "444:msteams"]
+	  resend_interval_seconds = 600
+   },
+ ]
+ conditions = [
+	{
+	  metric_name      = "synthetics.https.response.time"
+	  threshold        = ">=3000ms"
+	  duration         = "5m"
+	  not_reporting    = false
+	  aggregation_type = "AVG"
+      query_search = "healthScore.categoryV2:bad"
+	  group_by_metric_tag = [
+		"host.name"
+	  ]
+	  include_tags = [
+		{
+		  name = "probe.city"
+		  values : [
+			"Tokyo",
+			"Sao Paulo"
+		  ]
+		}
+	  ],
+	  exclude_tags = [{
+		  name = "service.name"
+		  values : [
+			"test-service"
+		  ]
+		}]
+	},
+ ]
+ notifications = ["123", "456"]
+ runbook_link = "https://www.runbooklink.com"
+ trigger_delay_seconds = 300
 }
 `, name)
 }

--- a/internal/provider/alert_schema.go
+++ b/internal/provider/alert_schema.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -118,11 +117,8 @@ func (r *alertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						},
 						"resend_interval_seconds": schema.Int64Attribute{
 							Description: "How often should the notification be resent in case alert keeps being triggered. " +
-								"Null means notification is sent only once. Valid values are 60, 600, 3600, 86400.",
+								"Null means notification is sent only once. Value must be between 60 and 86400 seconds, and value must be divisible by 60.",
 							Optional: true,
-							Validators: []validator.Int64{
-								int64validator.OneOf(60, 600, 3600, 86400),
-							},
 						},
 					},
 				},
@@ -201,7 +197,7 @@ func (r *alertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						},
 						"target_entity_types": schema.ListAttribute{
 							Description: "The entity types that the alert will be applied to. Must match across all alert conditions.",
-							Required:    true,
+							Optional:    true,
 							ElementType: types.StringType,
 						},
 						"include_tags": schema.SetNestedAttribute{
@@ -265,7 +261,7 @@ func (r *alertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			},
 			"trigger_delay_seconds": schema.Int64Attribute{
 				Description: "Trigger the alert after the alert condition persists for a specific duration. This prevents false positives. " +
-					"Value must be between 60 and 86400 seconds, and value has to be divisible by 60.",
+					"Value must be between 60 and 86400 seconds, and value must be divisible by 60.",
 				Optional: true,
 				Computed: true,
 				Default:  int64default.StaticInt64(0),


### PR DESCRIPTION
_No entity type is needed to create a metric group alert.
More precisely, it is necessary to drop the entire entityFilter field when calling the Alerting API because presence/absence of this field determines the type of the Alert definition (Entity vs Metric group)._

alert resource `target_entity_types` is now optional
If `target_entity_types` is nil, then do not create and set `EntityFilter` in the graphQL request. 
Added unit test for metric group alerting.

