### PR TITLE
Add property to clear alert after no data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/joho/godotenv v1.5.1
-	github.com/solarwinds/swo-client-go v0.0.18
+	github.com/solarwinds/swo-client-go v0.0.19
 	github.com/solarwinds/swo-sdk-go/swov1 v0.9.0
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b
 )

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/solarwinds/swo-client-go v0.0.18 h1:Bz9By/gUs0iAXrMPJR8CWn2E9V5UJbCPZZrGAXh8UEs=
-github.com/solarwinds/swo-client-go v0.0.18/go.mod h1:SbUBXaZsLPiIn5w+8xwoAogDW7tbQbTPAbA1YOAxgLE=
+github.com/solarwinds/swo-client-go v0.0.19 h1:NQbZF+TAsh4kTBJU9iNL/L0LDiElYDS5Fl6A9TRIBEk=
+github.com/solarwinds/swo-client-go v0.0.19/go.mod h1:SbUBXaZsLPiIn5w+8xwoAogDW7tbQbTPAbA1YOAxgLE=
 github.com/solarwinds/swo-sdk-go/swov1 v0.9.0 h1:BCXSrfvuPzI+85JUdJdR3TDqZfROGCJUKvvMqg/a8BY=
 github.com/solarwinds/swo-sdk-go/swov1 v0.9.0/go.mod h1:meAZLRWrtJTD9xD2ixBZRkC9Zsr/CPdvf/6E24C63PY=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -202,6 +203,11 @@ func (model *alertResourceModel) toAlertDefinitionInput(ctx context.Context, dia
 	}
 
 	triggerDelay := int(model.TriggerDelaySeconds.ValueInt64())
+	var noDataResetSeconds *int
+	if p := model.NoDataResetSeconds.ValueInt64Pointer(); p != nil {
+		value := int(*p)
+		noDataResetSeconds = &value
+	}
 	actions := model.toAlertActionInput(ctx, diags)
 	if diags.HasError() {
 		return swoClient.AlertDefinitionInput{}
@@ -216,6 +222,7 @@ func (model *alertResourceModel) toAlertDefinitionInput(ctx context.Context, dia
 		Condition:           conditions,
 		RunbookLink:         model.RunbookLink.ValueStringPointer(),
 		TriggerDelaySeconds: &triggerDelay,
+		NoDataResetSeconds:  noDataResetSeconds,
 	}
 }
 

--- a/internal/provider/alert_schema.go
+++ b/internal/provider/alert_schema.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -27,6 +28,7 @@ type alertResourceModel struct {
 	TriggerResetActions types.Bool   `tfsdk:"trigger_reset_actions"`
 	RunbookLink         types.String `tfsdk:"runbook_link"`
 	TriggerDelaySeconds types.Int64  `tfsdk:"trigger_delay_seconds"`
+	NoDataResetSeconds  types.Int64  `tfsdk:"no_data_reset_seconds"`
 }
 
 type alertConditionModel struct {
@@ -316,6 +318,10 @@ func (r *alertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Optional: true,
 				Computed: true,
 				Default:  int64default.StaticInt64(0),
+			},
+			"no_data_reset_seconds": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of seconds after which the alert is reset if no metric data is received.",
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -31,12 +31,14 @@ var (
 
 func main() {
 	var debug bool
+	var identity string
 
 	flag.BoolVar(&debug, "debug", false, "Set to true to run the provider with support for debuggers.")
+	flag.StringVar(&identity, "identity", "github.com/solarwinds/swo", "Provider identity to use.")
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "github.com/solarwinds/swo",
+		Address: identity,
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
Adds option `no_data_reset_seconds` to control the number of seconds for a reset when no data is available.