### PR TITLE
Fix for required API validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/joho/godotenv v1.5.1
-	github.com/solarwinds/swo-client-go v0.0.19
+	github.com/solarwinds/swo-client-go v0.0.21
 	github.com/solarwinds/swo-sdk-go/swov1 v0.9.0
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b
 )

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/solarwinds/swo-client-go v0.0.19 h1:NQbZF+TAsh4kTBJU9iNL/L0LDiElYDS5Fl6A9TRIBEk=
-github.com/solarwinds/swo-client-go v0.0.19/go.mod h1:SbUBXaZsLPiIn5w+8xwoAogDW7tbQbTPAbA1YOAxgLE=
+github.com/solarwinds/swo-client-go v0.0.21 h1:TcRO1UjgER1MP1JoMZUnrZ6EbwpA/thguEVZQhfrdos=
+github.com/solarwinds/swo-client-go v0.0.21/go.mod h1:SbUBXaZsLPiIn5w+8xwoAogDW7tbQbTPAbA1YOAxgLE=
 github.com/solarwinds/swo-sdk-go/swov1 v0.9.0 h1:BCXSrfvuPzI+85JUdJdR3TDqZfROGCJUKvvMqg/a8BY=
 github.com/solarwinds/swo-sdk-go/swov1 v0.9.0/go.mod h1:meAZLRWrtJTD9xD2ixBZRkC9Zsr/CPdvf/6E24C63PY=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -208,6 +208,15 @@ func (model *alertResourceModel) toAlertDefinitionInput(ctx context.Context, dia
 		value := int(*p)
 		noDataResetSeconds = &value
 	}
+
+	// The API forces a match between NoDataResetSeconds and TimeRangeSeconds in EntityFilter.
+	for _, condition := range conditions {
+		if condition.Type != string(swoClient.AlertAttributeType) || condition.EntityFilter == nil {
+			continue
+		}
+		condition.EntityFilter.TimeRangeSeconds = noDataResetSeconds
+	}
+
 	actions := model.toAlertActionInput(ctx, diags)
 	if diags.HasError() {
 		return swoClient.AlertDefinitionInput{}


### PR DESCRIPTION
This is a fix for a validation that the API does. When `NoDataResetSeconds` is set, the value must also match what's in every attribute type node's entity filter.