### PR TITLE
Add condition disjunction

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -92,12 +92,13 @@ resource "swo_alert" "alert_with_attribute_conditions" {
 
 ### Required
 
-- `conditions` (Attributes Set) One or more conditions that must be met to trigger the alert. These conditions are evaluated as a logical AND. (see [below for nested schema](#nestedatt--conditions))
+- `conditions` (Attributes Set) One or more conditions that must be met to trigger the alert. Multiple conditions are merged using `conditions_operation`. (see [below for nested schema](#nestedatt--conditions))
 - `name` (String) Alert name.
 - `severity` (String) Alert severity. Valid values are [`INFO`|`WARNING`|`CRITICAL`].
 
 ### Optional
 
+- `conditions_operation` (String) Defines whether conditions are combined using `AND` or `OR`. Ignored when there is only one condition. Default is `AND`.
 - `description` (String) Alert description.
 - `enabled` (Boolean) True if the alert should be evaluated. Default is `true`.
 - `no_data_reset_seconds` (Number) Number of seconds after which the alert is reset if no metric data is received. Default is `86400`.

--- a/internal/provider/alert_resource_acc_test.go
+++ b/internal/provider/alert_resource_acc_test.go
@@ -188,7 +188,7 @@ func TestAccAlertResourceNotReporting(t *testing.T) {
 	})
 }
 
-func TestMultiMetricConditionAlertResource(t *testing.T) {
+func TestAndMetricConditionAlertResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -196,10 +196,10 @@ func TestMultiMetricConditionAlertResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testMultiConditionAlertResourceConfig("test-acc Mock Multi Condition Alert Name"),
+				Config: testAndConditionAlertResourceConfig("test-acc Mock AND Multi Condition Alert Name"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 
-					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc Mock Multi Condition Alert Name"),
+					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc Mock AND Multi Condition Alert Name"),
 					resource.TestCheckResourceAttr("swo_alert.test", "description", ""),
 					resource.TestCheckResourceAttr("swo_alert.test", "severity", "INFO"),
 					resource.TestCheckResourceAttr("swo_alert.test", "enabled", "false"),
@@ -210,6 +210,7 @@ func TestMultiMetricConditionAlertResource(t *testing.T) {
 					// Verify the number of conditions.
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.#", "3"),
 					// Verify the conditions.
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions_operation", "AND"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.target_entity_types.0", "Website"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.metric_name", "sw.metrics.healthscore"),
 					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.threshold", "<10"),
@@ -247,9 +248,79 @@ func TestMultiMetricConditionAlertResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testMultiConditionAlertResourceConfig("test-acc test_two"),
+				Config: testAndConditionAlertResourceConfig("test-acc AND test_two"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc test_two"),
+					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc AND test_two"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestOrMetricConditionAlertResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testOrConditionAlertResourceConfig("test-acc Mock OR Multi Condition Alert Name"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+
+					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc Mock OR Multi Condition Alert Name"),
+					resource.TestCheckResourceAttr("swo_alert.test", "description", ""),
+					resource.TestCheckResourceAttr("swo_alert.test", "severity", "INFO"),
+					resource.TestCheckResourceAttr("swo_alert.test", "enabled", "false"),
+					// Verify actions
+					resource.TestCheckResourceAttr("swo_alert.test", "notification_actions.0.configuration_ids.0", "333:email"),
+					resource.TestCheckResourceAttr("swo_alert.test", "notification_actions.0.configuration_ids.1", "444:msteams"),
+					resource.TestCheckResourceAttr("swo_alert.test", "notification_actions.0.resend_interval_seconds", "600"),
+					// Verify the number of conditions.
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.#", "3"),
+					// Verify the conditions.
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions_operation", "OR"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.target_entity_types.0", "Website"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.metric_name", "sw.metrics.healthscore"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.threshold", "<10"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.not_reporting", "false"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.duration", "5m"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.aggregation_type", "AVG"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.entity_ids.0", "e-1521946194448543744"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.entity_ids.1", "e-1521947552186691584"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.0.query_search", "healthScore.categoryV2:bad"),
+
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.target_entity_types.0", "Website"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.metric_name", "synthetics.https.response.time"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.threshold", ">=3000"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.not_reporting", "false"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.duration", "5m"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.aggregation_type", "AVG"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.entity_ids.0", "e-1521946194448543744"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.entity_ids.1", "e-1521947552186691584"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.1.query_search", "healthScore.categoryV2:bad"),
+
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.target_entity_types.0", "Website"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.metric_name", "synthetics.status"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.not_reporting", "true"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.duration", "30m"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.aggregation_type", "COUNT"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.entity_ids.0", "e-1521946194448543744"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.entity_ids.1", "e-1521947552186691584"),
+					resource.TestCheckResourceAttr("swo_alert.test", "conditions.2.query_search", "healthScore.categoryV2:bad"),
+
+					resource.TestCheckResourceAttr("swo_alert.test", "notifications.0", "123"),
+					resource.TestCheckResourceAttr("swo_alert.test", "notifications.1", "456"),
+					resource.TestCheckResourceAttr("swo_alert.test", "runbook_link", "https://www.runbooklink.com"),
+					resource.TestCheckResourceAttr("swo_alert.test", "trigger_delay_seconds", "600"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: testAndConditionAlertResourceConfig("test-acc OR test_two"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("swo_alert.test", "name", "test-acc OR test_two"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -350,7 +421,7 @@ resource "swo_alert" "test" {
 `, name)
 }
 
-func testMultiConditionAlertResourceConfig(name string) string {
+func testAndConditionAlertResourceConfig(name string) string {
 	return providerConfig() + fmt.Sprintf(`
 
 resource "swo_alert" "test" {
@@ -364,6 +435,68 @@ resource "swo_alert" "test" {
 	  resend_interval_seconds = 600
    },
  ]
+ conditions = [
+	{
+	  metric_name      = "synthetics.https.response.time"
+	  threshold        = ">=3000"
+	  duration         = "5m"
+	  not_reporting    = false
+	  aggregation_type = "AVG"
+	  target_entity_types = ["Website"]
+	  entity_ids = [
+		"e-1521946194448543744",
+		"e-1521947552186691584"
+	  ]
+      query_search = "healthScore.categoryV2:bad"
+	},
+	{
+	  metric_name      = "sw.metrics.healthscore"
+	  threshold        = "<10"
+	  duration         = "5m"
+	  not_reporting    = false
+	  aggregation_type = "AVG"
+	  target_entity_types = ["Website"]
+	  entity_ids = [
+		"e-1521946194448543744",
+		"e-1521947552186691584"
+	  ]
+      query_search = "healthScore.categoryV2:bad"
+	},
+	{
+	  metric_name      = "synthetics.status"
+	  not_reporting    = true
+	  duration         = "30m"
+	  aggregation_type = "COUNT"
+	  target_entity_types = ["Website"]
+	  entity_ids = [
+		"e-1521946194448543744",
+		"e-1521947552186691584"
+	  ]
+      query_search = "healthScore.categoryV2:bad"
+	},
+ ]
+ notifications = ["123", "456"]
+ runbook_link = "https://www.runbooklink.com"
+ trigger_delay_seconds = 600
+}
+`, name)
+}
+
+func testOrConditionAlertResourceConfig(name string) string {
+	return providerConfig() + fmt.Sprintf(`
+
+resource "swo_alert" "test" {
+ name        = %[1]q
+ description = ""
+ severity    = "INFO"
+ enabled     = false
+ notification_actions = [
+   {
+	  configuration_ids = ["333:email", "444:msteams"]
+	  resend_interval_seconds = 600
+   },
+ ]
+ conditions_operation  = "OR"
  conditions = [
 	{
 	  metric_name      = "synthetics.https.response.time"


### PR DESCRIPTION
Add `conditions_operator` to the model, so that users can use `AND` or `OR` to join conditions together. It defaults to `AND` to retain current behavior.