### PR TITLE
chore: Migrate Windows signing from SignPath to Azure Trusted Signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
       - name: Install dependencies
         run: go get .
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     needs: [docs-verify]
-    environment: prod
+    # environment: prod -- temporarily removed for ATS signing test via workflow_dispatch
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch: # temporary: for testing ATS signing without a tag
 
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.
@@ -92,6 +93,7 @@ jobs:
           files-to-sign: "*.exe,*.dll"
           cert-profile: ${{ vars.ATS_CERT_PROFILE }}
       - name: Run GoReleaser
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Build binaries
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: "~> v1"
+          version: "1.26.2"
           args: build --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,7 +95,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: "~> v1"
+          version: "1.26.2"
           args: release --skip-build
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 # GitHub considers creating releases and uploading assets as writing contents.
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   docs-verify:
@@ -56,22 +57,49 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-      - name: Install SignPath Powershell module
-        shell: pwsh
-        run: Install-Module -Name SignPath -Confirm:$False -Force
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
+      - name: Checkout solarwinds-actions/gha-signing
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/checkout@v4
         with:
-          args: release --clean
-          version: 1.26.2
+          repository: solarwinds-actions/gha-signing
+          token: ${{ secrets.FGPAT_ENOPS_7950_SOLARWINDS_ACTIONS }}
+          ref: v1
+          path: ./.github/actions/gha-signing
+      - name: Build binaries
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v1"
+          args: build --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          SWO_ISSUER_ID: ${{ secrets.SWO_ISSUER_ID }}
+          SWO_KEY_ID: ${{ secrets.SWO_KEY_ID }}
+          SWO_MAC_P8_FILE: ${{ secrets.SWO_MAC_P8_FILE }}
+          SWO_MAC_P12_CERT: ${{ secrets.SWO_MAC_P12_CERT }}
+          SWO_P12_PASSWORD: ${{ secrets.SWO_P12_PASSWORD }}
+      - name: Azure Login (Federated Identity)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign Files
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: ./.github/actions/gha-signing/ats-sign
+        with:
+          files-to-sign: "*.exe,*.dll"
+          cert-profile: ${{ vars.ATS_CERT_PROFILE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v1"
+          args: release --skip-build
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          SP_CI_USER_TOKEN: ${{ secrets.SIGNPATH_CI_USER_TOKEN }}
-          SP_ORGANIZATION_ID: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
-          SP_PROJECT: terraform-provider-swo
-
           SWO_ISSUER_ID: ${{ secrets.SWO_ISSUER_ID }}
           SWO_KEY_ID: ${{ secrets.SWO_KEY_ID }}
           SWO_MAC_P8_FILE: ${{ secrets.SWO_MAC_P8_FILE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,6 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Checkout solarwinds-actions/gha-signing
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/checkout@v4
         with:
           repository: solarwinds-actions/gha-signing
@@ -70,7 +69,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v1"
-          args: build --clean
+          args: build --clean${{ github.event_name == 'workflow_dispatch' && ' --snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
@@ -80,14 +79,12 @@ jobs:
           SWO_MAC_P12_CERT: ${{ secrets.SWO_MAC_P12_CERT }}
           SWO_P12_PASSWORD: ${{ secrets.SWO_P12_PASSWORD }}
       - name: Azure Login (Federated Identity)
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: azure/login@v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - name: Sign Files
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: ./.github/actions/gha-signing/ats-sign
         with:
           files-to-sign: "*.exe,*.dll"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch: # temporary: for testing ATS signing without a tag
 
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.
@@ -42,7 +41,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     needs: [docs-verify]
-    # environment: prod -- temporarily removed for ATS signing test via workflow_dispatch
+    environment: prod
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,6 +58,7 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Checkout solarwinds-actions/gha-signing
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/checkout@v4
         with:
           repository: solarwinds-actions/gha-signing
@@ -69,7 +69,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v1"
-          args: build --clean${{ github.event_name == 'workflow_dispatch' && ' --snapshot' || '' }}
+          args: build --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
@@ -79,12 +79,14 @@ jobs:
           SWO_MAC_P12_CERT: ${{ secrets.SWO_MAC_P12_CERT }}
           SWO_P12_PASSWORD: ${{ secrets.SWO_P12_PASSWORD }}
       - name: Azure Login (Federated Identity)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: azure/login@v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - name: Sign Files
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: ./.github/actions/gha-signing/ats-sign
         with:
           files-to-sign: "*.exe,*.dll"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,13 +53,6 @@ builds:
     - "-s -w -X 'main.version=v{{ .Version }}'"
   targets:
     - windows_amd64
-  hooks:
-    post:
-      - env:
-          - SP_SIGNING_POLICY=Release
-          - SP_ARTIFACT_CONFIGURATION=exe
-        cmd: pwsh -c "Submit-SigningRequest -ApiToken "$env:SP_CI_USER_TOKEN" -OrganizationId "$env:SP_ORGANIZATION_ID" -ProjectSlug "$env:SP_PROJECT" -SigningPolicySlug "$env:SP_SIGNING_POLICY" -ArtifactConfigurationSlug "$env:SP_ARTIFACT_CONFIGURATION" -InputArtifactPath '{{ .Path }}' -OutputArtifactPath '{{ .Path }}' -Force -WaitForCompletion"
-        output: true
 
 archives:
 - format: zip

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	websiteExpBackoffMaxInterval = 30 * time.Second
-	websiteExpBackoffMaxElapsed  = 2 * time.Minute
+	websiteExpBackoffInitialInterval = 5 * time.Second
+	websiteExpBackoffMaxInterval     = 30 * time.Second
+	websiteExpBackoffMaxElapsed      = 2 * time.Minute
 )
 
 var (
@@ -595,23 +596,34 @@ func stringToTestFromType(typeStr string) (components.Type, error) {
 }
 
 func websiteReadRetry(ctx context.Context, id string, operation func(context.Context, string) (*components.DemGetWebsiteResponse, error)) (*components.DemGetWebsiteResponse, error) {
-	var website *components.DemGetWebsiteResponse
-
 	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = websiteExpBackoffInitialInterval
 	expBackoff.MaxInterval = websiteExpBackoffMaxInterval
+
+	var lastResult *components.DemGetWebsiteResponse
 
 	website, err := backoff.Retry(ctx, func() (*components.DemGetWebsiteResponse, error) {
 		result, err := operation(ctx, id)
 		if err != nil {
+			lastResult = nil
 			return nil, err
 		}
 
 		if result == nil {
+			lastResult = nil
 			return nil, ErrNoWebsiteEntityReturned
 		}
 
 		if result.ID == "" {
+			lastResult = nil
 			return nil, ErrWebsiteEntityNoData
+		}
+
+		// Require two consecutive identical reads before accepting the result.
+		// This prevents a single stale API response from being committed to state.
+		if lastResult == nil || lastResult.Name != result.Name || lastResult.URL != result.URL {
+			lastResult = result
+			return nil, fmt.Errorf("waiting for stable website state")
 		}
 
 		return result, nil

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -72,6 +72,7 @@ var (
 	_ resource.Resource                = &websiteResource{}
 	_ resource.ResourceWithConfigure   = &websiteResource{}
 	_ resource.ResourceWithImportState = &websiteResource{}
+	_ resource.ResourceWithModifyPlan  = &websiteResource{}
 )
 
 func NewWebsiteResource() resource.Resource {
@@ -89,6 +90,53 @@ func (r *websiteResource) Metadata(ctx context.Context, req resource.MetadataReq
 func (r *websiteResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	client, _ := req.ProviderData.(providerClients)
 	r.client = client.SwoV1Client
+}
+
+func (r *websiteResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Nothing to do on destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var tfPlan websiteResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &tfPlan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if tfPlan.Monitoring.IsUnknown() {
+		return
+	}
+
+	var tfMonitoring websiteMonitoring
+	resp.Diagnostics.Append(tfPlan.Monitoring.As(ctx, &tfMonitoring, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// options reflects which monitoring types are configured — compute it from
+	// the plan so Terraform shows the expected value instead of (known after apply).
+	planOptions := monitoringOptions{
+		IsAvailabilityActive: types.BoolValue(!tfMonitoring.Availability.IsNull() && !tfMonitoring.Availability.IsUnknown()),
+		IsRumActive:          types.BoolValue(!tfMonitoring.Rum.IsNull() && !tfMonitoring.Rum.IsUnknown()),
+	}
+
+	optionsObject, d := types.ObjectValueFrom(ctx, MonitoringOptionsAttributeTypes(), planOptions)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tfMonitoring.Options = optionsObject
+
+	monitoringObject, d := types.ObjectValueFrom(ctx, WebsiteMonitoringAttributeTypes(), tfMonitoring)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tfPlan.Monitoring = monitoringObject
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, tfPlan)...)
 }
 
 func (r *websiteResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/website_resource.go
+++ b/internal/provider/website_resource.go
@@ -31,6 +31,7 @@ var (
 	ErrAvailabilitySettingsNotUpdated = errors.New("availability settings not yet updated")
 	ErrRUMSettingsNotUpdated          = errors.New("RUM settings not yet updated")
 	ErrWebsiteNameNotUpdated          = errors.New("website name not yet updated")
+	ErrWebsiteStateNotStable          = errors.New("waiting for stable website state")
 	ErrWebsiteURLNotUpdated           = errors.New("website URL not yet updated")
 	ErrUnsupportedOperator            = errors.New("unsupported operator")
 	ErrUnsupportedProtocol            = errors.New("unsupported protocol")
@@ -623,7 +624,7 @@ func websiteReadRetry(ctx context.Context, id string, operation func(context.Con
 		// This prevents a single stale API response from being committed to state.
 		if lastResult == nil || lastResult.Name != result.Name || lastResult.URL != result.URL {
 			lastResult = result
-			return nil, fmt.Errorf("waiting for stable website state")
+			return nil, ErrWebsiteStateNotStable
 		}
 
 		return result, nil

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -224,14 +226,23 @@ func (r *websiteResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					"options": schema.SingleNestedAttribute{
 						Description: "The Website monitoring options.",
 						Computed:    true,
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
 						Attributes: map[string]schema.Attribute{
 							"is_availability_active": schema.BoolAttribute{
 								Description: "Is availability monitoring active?",
 								Computed:    true,
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"is_rum_active": schema.BoolAttribute{
 								Description: "Is RUM monitoring active?",
 								Computed:    true,
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
 							},
 						},
 					},

--- a/internal/provider/website_schema.go
+++ b/internal/provider/website_schema.go
@@ -16,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -226,23 +224,14 @@ func (r *websiteResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					"options": schema.SingleNestedAttribute{
 						Description: "The Website monitoring options.",
 						Computed:    true,
-						PlanModifiers: []planmodifier.Object{
-							objectplanmodifier.UseStateForUnknown(),
-						},
 						Attributes: map[string]schema.Attribute{
 							"is_availability_active": schema.BoolAttribute{
 								Description: "Is availability monitoring active?",
 								Computed:    true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.UseStateForUnknown(),
-								},
 							},
 							"is_rum_active": schema.BoolAttribute{
 								Description: "Is RUM monitoring active?",
 								Computed:    true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.UseStateForUnknown(),
-								},
 							},
 						},
 					},


### PR DESCRIPTION
## Summary

Migrates Windows binary signing from SignPath to Azure Trusted Signing (ATS).

**Signing migration:**
- Removes SignPath goreleaser post-build hook and secrets (`SIGNPATH_CI_USER_TOKEN`, `SIGNPATH_ORGANIZATION_ID`)
- Adds `id-token: write` for Azure OIDC
- Splits goreleaser into `build --clean` → sign → `release --skip-build` so the Windows binary is signed before archiving
- Adds the three ATS steps in order: checkout `gha-signing` → Azure Login (OIDC) → Sign Files (`*.exe,*.dll`)
- Pins goreleaser to v1.26.2, upgrades goreleaser-action to v6

All required secrets/vars are configured in the `prod` environment.

**CI fixes (pre-existing):**
- Adds `hashicorp/setup-terraform@v3` to fix an expired GPG key error blocking acceptance tests
- Fixes `monitoring.options` plan drift in the website resource via `ModifyPlan`
- Increases website read retry initial interval to 5s with a two-consecutive-reads stability check

## Signing verification

Partially verified via `workflow_dispatch` on this branch (without `prod` environment):

- ✅ `goreleaser build --clean --snapshot`
- ✅ `Checkout solarwinds-actions/gha-signing` — token valid, action checked out at `ref: v1`
- ⚠️ `Azure Login` — expected failure; Azure vars are scoped to `prod` and confirmed present

Full signing will execute on the first real tag push with `prod` environment access.