### PR TITLE
fix: move gha-signing checkout to after goreleaser build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,14 +57,6 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-      - name: Checkout solarwinds-actions/gha-signing
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        uses: actions/checkout@v4
-        with:
-          repository: solarwinds-actions/gha-signing
-          token: ${{ secrets.FGPAT_ENOPS_7950_SOLARWINDS_ACTIONS }}
-          ref: v1
-          path: ./.github/actions/gha-signing
       - name: Build binaries
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -78,6 +70,14 @@ jobs:
           SWO_MAC_P8_FILE: ${{ secrets.SWO_MAC_P8_FILE }}
           SWO_MAC_P12_CERT: ${{ secrets.SWO_MAC_P12_CERT }}
           SWO_P12_PASSWORD: ${{ secrets.SWO_P12_PASSWORD }}
+      - name: Checkout solarwinds-actions/gha-signing
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/checkout@v4
+        with:
+          repository: solarwinds-actions/gha-signing
+          token: ${{ secrets.FGPAT_ENOPS_7950_SOLARWINDS_ACTIONS }}
+          ref: v1
+          path: ./.github/actions/gha-signing
       - name: Azure Login (Federated Identity)
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: azure/login@v2


### PR DESCRIPTION
## Summary

The `Checkout solarwinds-actions/gha-signing` step was running before `Build binaries`, which caused goreleaser to fail with a dirty git state — the checked-out `.github/actions/` directory appeared as an untracked file.

Moves the checkout step to after `Build binaries` so the working tree is clean when goreleaser validates git state. The signing action is still available before it's needed for the `Sign Files` step.