### PR TITLE
Add "apiTokenName" property to CircleCI integration

### DIFF
--- a/docs/resources/circleciintegration.md
+++ b/docs/resources/circleciintegration.md
@@ -44,7 +44,7 @@ resource "circleci_webhook" "service_a" {
 
 - `api_token` (String, Sensitive) The CircleCI API token. Used to fetch project metadata and logs.
 - `api_token_name` (String) A label for the stored CircleCI API token. Required when api_token is set.
-- `receiver_base` (String) The receiver URL base. Defaults to the SWO production endpoint. Default is `https://webhook.swo.solarwinds.com/webhook`.
+- `receiver_base` (String) The receiver URL base. Defaults to the SWO production endpoint. Default is `https://webhook.swo.cloud.solarwinds.com/webhook`.
 
 ### Read-Only
 

--- a/docs/resources/circleciintegration.md
+++ b/docs/resources/circleciintegration.md
@@ -43,6 +43,7 @@ resource "circleci_webhook" "service_a" {
 ### Optional
 
 - `api_token` (String, Sensitive) The CircleCI API token. Used to fetch project metadata and logs.
+- `api_token_name` (String) A label for the stored CircleCI API token. Required when api_token is set.
 - `receiver_base` (String) The receiver URL base. Defaults to the SWO production endpoint. Default is `https://webhook.swo.solarwinds.com/webhook`.
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/joho/godotenv v1.5.1
-	github.com/solarwinds/swo-client-go v0.0.24
+	github.com/solarwinds/swo-client-go v0.0.25
 	github.com/solarwinds/swo-sdk-go/swov1 v0.12.1
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b
 )

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/solarwinds/swo-client-go v0.0.24 h1:0yJhE/ftmky8UBI1t2WcO4Ib9PrQ7jvdSbL+nXHhSjA=
-github.com/solarwinds/swo-client-go v0.0.24/go.mod h1:eiOec/yfEuHfsMBW6tX4gxBY2acFnOyRPryXhImkHac=
+github.com/solarwinds/swo-client-go v0.0.25 h1:fhIDsTB+nHKJDmXcTOFBH9UuI3U0wnJjv8/8M0V772Y=
+github.com/solarwinds/swo-client-go v0.0.25/go.mod h1:eiOec/yfEuHfsMBW6tX4gxBY2acFnOyRPryXhImkHac=
 github.com/solarwinds/swo-sdk-go/swov1 v0.12.1 h1:gcpu1W+/odq692YvvCpMQTWvBFHJp5/3fnml59JLpy8=
 github.com/solarwinds/swo-sdk-go/swov1 v0.12.1/go.mod h1:ZgHJ5sJsKmck0rng34NZugA3cXPZ2jxcp2YYErYfsE4=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/internal/provider/circleci_integration_resource.go
+++ b/internal/provider/circleci_integration_resource.go
@@ -42,10 +42,20 @@ func (r *circleCIIntegrationResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
+	if hasApiTokenWithoutName(tfPlan) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("api_token_name"),
+			"Missing api_token_name",
+			"api_token_name is required when api_token is set.",
+		)
+		return
+	}
+
 	result, err := r.client.CircleCIIntegrationService().Create(
 		ctx,
 		tfPlan.Name.ValueString(),
 		tfPlan.ApiToken.ValueStringPointer(),
+		tfPlan.ApiTokenName.ValueStringPointer(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",

--- a/internal/provider/circleci_integration_resource.go
+++ b/internal/provider/circleci_integration_resource.go
@@ -92,11 +92,21 @@ func (r *circleCIIntegrationResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
+	if hasApiTokenWithoutName(tfPlan) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("api_token_name"),
+			"Missing api_token_name",
+			"api_token_name is required when api_token is set.",
+		)
+		return
+	}
+
 	result, err := r.client.CircleCIIntegrationService().Update(
 		ctx,
 		tfState.Id.ValueString(),
 		tfPlan.Name.ValueStringPointer(),
 		tfPlan.ApiToken.ValueStringPointer(),
+		tfPlan.ApiTokenName.ValueStringPointer(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
@@ -126,4 +136,12 @@ func (r *circleCIIntegrationResource) Delete(ctx context.Context, req resource.D
 
 func (r *circleCIIntegrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// hasApiTokenWithoutName reports whether an api_token was supplied without an api_token_name,
+// which the backend rejects (a stored token's presence is signalled by its name).
+func hasApiTokenWithoutName(model circleCIIntegrationResourceModel) bool {
+	hasToken := !model.ApiToken.IsNull() && model.ApiToken.ValueString() != ""
+	hasName := !model.ApiTokenName.IsNull() && model.ApiTokenName.ValueString() != ""
+	return hasToken && !hasName
 }

--- a/internal/provider/circleci_integration_resource_test.go
+++ b/internal/provider/circleci_integration_resource_test.go
@@ -28,7 +28,7 @@ func TestAccCircleCIIntegrationResource(t *testing.T) {
 					resource.TestCheckResourceAttr("swo_circleciintegration.test", "name", "test-circleci-one"),
 					resource.TestCheckResourceAttrSet("swo_circleciintegration.test", "secret_token"),
 					resource.TestCheckResourceAttrSet("swo_circleciintegration.test", "receiver_url"),
-					resource.TestCheckResourceAttr("swo_circleciintegration.test", "receiver_base", "https://webhook.swo.solarwinds.com/webhook"),
+					resource.TestCheckResourceAttr("swo_circleciintegration.test", "receiver_base", defaultReceiverBase),
 					checkReceiverUrlMatchesBase("swo_circleciintegration.test"),
 				),
 			},

--- a/internal/provider/circleci_integration_schema.go
+++ b/internal/provider/circleci_integration_schema.go
@@ -18,6 +18,7 @@ type circleCIIntegrationResourceModel struct {
 	Id           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
 	ApiToken     types.String `tfsdk:"api_token"`
+	ApiTokenName types.String `tfsdk:"api_token_name"`
 	ReceiverBase types.String `tfsdk:"receiver_base"`
 	ReceiverUrl  types.String `tfsdk:"receiver_url"`
 	SecretToken  types.String `tfsdk:"secret_token"`
@@ -36,6 +37,10 @@ func (r *circleCIIntegrationResource) Schema(_ context.Context, _ resource.Schem
 				Description: "The CircleCI API token. Used to fetch project metadata and logs.",
 				Optional:    true,
 				Sensitive:   true,
+			},
+			"api_token_name": schema.StringAttribute{
+				Description: "A label for the stored CircleCI API token. Required when api_token is set.",
+				Optional:    true,
 			},
 			"receiver_base": schema.StringAttribute{
 				Description: "The receiver URL base. Defaults to the SWO production endpoint.",

--- a/internal/provider/circleci_integration_schema.go
+++ b/internal/provider/circleci_integration_schema.go
@@ -11,7 +11,7 @@ import (
 	"github.com/solarwinds/terraform-provider-swo/internal/planmodifier/stringmodifier"
 )
 
-const defaultReceiverBase = "https://webhook.swo.solarwinds.com/webhook"
+const defaultReceiverBase = "https://webhook.swo.cloud.solarwinds.com/webhook"
 
 // circleCIIntegrationResourceModel is the main resource model.
 type circleCIIntegrationResourceModel struct {

--- a/internal/provider/circleci_integration_validate_test.go
+++ b/internal/provider/circleci_integration_validate_test.go
@@ -1,0 +1,53 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestHasApiTokenWithoutName(t *testing.T) {
+	tests := []struct {
+		name      string
+		apiToken  types.String
+		tokenName types.String
+		want      bool
+	}{
+		{
+			name:      "token with name is fine",
+			apiToken:  types.StringValue("CCI-token"),
+			tokenName: types.StringValue("CI reader"),
+			want:      false,
+		},
+		{
+			name:      "token without name is invalid",
+			apiToken:  types.StringValue("CCI-token"),
+			tokenName: types.StringNull(),
+			want:      true,
+		},
+		{
+			name:      "token with empty name is invalid",
+			apiToken:  types.StringValue("CCI-token"),
+			tokenName: types.StringValue(""),
+			want:      true,
+		},
+		{
+			name:      "no token is fine regardless of name",
+			apiToken:  types.StringNull(),
+			tokenName: types.StringNull(),
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasApiTokenWithoutName(circleCIIntegrationResourceModel{
+				ApiToken:     tc.apiToken,
+				ApiTokenName: tc.tokenName,
+			})
+			if got != tc.want {
+				t.Errorf("hasApiTokenWithoutName() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds an api_token_name attribute to swo_circleciintegration, so a stored CircleCI API token can carry a human-readable label. The backend requires this label whenever a token is stored — the label's presence is what signals that a token exists — so without it Terraform could not manage tokenised integrations at all.

Also fixes an unrelated bug found while verifying: the default receiver_base pointed at a hostname that does not resolve.